### PR TITLE
Drop the build dependency on the Go compiler

### DIFF
--- a/admission_control/admission_control_proto/Cargo.toml
+++ b/admission_control/admission_control_proto/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 futures = "0.1.28"
 futures03 = { version = "=0.3.0-alpha.17", package = "futures-preview" }
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 protobuf = "2.7"
 
 failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }

--- a/admission_control/admission_control_proto/Cargo.toml
+++ b/admission_control/admission_control_proto/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "admission_control_proto"
+name = "solana_libra_admission_control_proto"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -12,11 +12,11 @@ futures03 = { version = "=0.3.0-alpha.17", package = "futures-preview" }
 grpcio = "0.4.3"
 protobuf = "2.7"
 
-failure = { package = "failure_ext", path = "../../common/failure_ext" }
-logger = { path = "../../common/logger" }
-mempool = { path = "../../mempool" }
-proto_conv = { path = "../../common/proto_conv" }
-types = { path = "../../types" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+logger = { path = "../../common/logger", package = "solana_libra_logger" }
+mempool = { path = "../../mempool", package = "solana_libra_mempool" }
+proto_conv = { path = "../../common/proto_conv", package = "solana_libra_proto_conv" }
+types = { path = "../../types", package = "solana_libra_types" }
 
 [build-dependencies]
-build_helpers = { path = "../../common/build_helpers" }
+build_helpers = { path = "../../common/build_helpers", package = "solana_libra_build_helpers" }

--- a/admission_control/admission_control_service/Cargo.toml
+++ b/admission_control/admission_control_service/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "admission_control_service"
+name = "solana_libra_admission_control_service"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -13,24 +13,24 @@ grpcio = "0.4.3"
 lazy_static = "1.3.0"
 protobuf = "2.7"
 
-admission_control_proto = { path = "../admission_control_proto" }
-config = { path = "../../config" }
-crypto = { path = "../../crypto/legacy_crypto" }
-debug_interface = { path = "../../common/debug_interface" }
-failure = { package = "failure_ext", path = "../../common/failure_ext" }
-executable_helpers = { path = "../../common/executable_helpers" }
-grpc_helpers = { path = "../../common/grpc_helpers" }
-logger = { path = "../../common/logger" }
-mempool = { path = "../../mempool" }
-metrics = { path = "../../common/metrics" }
-proto_conv = { path = "../../common/proto_conv" }
-storage_client = { path = "../../storage/storage_client" }
-types = { path = "../../types" }
-vm_validator = { path = "../../vm_validator" }
+admission_control_proto = { path = "../admission_control_proto", package = "solana_libra_admission_control_proto" }
+config = { path = "../../config", package = "solana_libra_config" }
+crypto = { path = "../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+debug_interface = { path = "../../common/debug_interface", package = "solana_libra_debug_interface" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+executable_helpers = { path = "../../common/executable_helpers", package = "solana_libra_executable_helpers" }
+grpc_helpers = { path = "../../common/grpc_helpers", package = "solana_libra_grpc_helpers" }
+logger = { path = "../../common/logger", package = "solana_libra_logger" }
+mempool = { path = "../../mempool", package = "solana_libra_mempool" }
+metrics = { path = "../../common/metrics", package = "solana_libra_metrics" }
+proto_conv = { path = "../../common/proto_conv", package = "solana_libra_proto_conv" }
+storage_client = { path = "../../storage/storage_client", package = "solana_libra_storage_client" }
+types = { path = "../../types", package = "solana_libra_types" }
+vm_validator = { path = "../../vm_validator", package = "solana_libra_vm_validator" }
 
 [dev-dependencies]
 assert_matches = "1.3.0"
-storage_service = { path = "../../storage/storage_service" }
+storage_service = { path = "../../storage/storage_service", package = "solana_libra_storage_service" }
 
 [build-dependencies]
-build_helpers = { path = "../../common/build_helpers" }
+build_helpers = { path = "../../common/build_helpers", package = "solana_libra_build_helpers" }

--- a/admission_control/admission_control_service/Cargo.toml
+++ b/admission_control/admission_control_service/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 futures = "0.1.28"
 futures03 = { version = "=0.3.0-alpha.17", package = "futures-preview" }
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 lazy_static = "1.3.0"
 protobuf = "2.7"
 

--- a/admission_control/admission_control_service/src/main.rs
+++ b/admission_control/admission_control_service/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use solana_libra_admission_control_service as admission_control_service;
+
 use admission_control_service::admission_control_node;
 use executable_helpers::helpers::{
     setup_executable, ARG_CONFIG_PATH, ARG_DISABLE_LOGGING, ARG_PEER_ID,

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "benchmark"
+name = "solana_libra_benchmark"
 version = "0.1.0"
 authors = ["Libra <oncall+libra@xmail.facebook.com>"]
 publish = false
@@ -16,18 +16,18 @@ protobuf = "2.7"
 regex = "1.1.9"
 structopt = "0.2.15"
 
-admission_control_proto = { path = "../admission_control/admission_control_proto" }
-client = { path = "../client" }
-config = { path = "../config" }
-crypto = { path = "../crypto/legacy_crypto" }
-debug_interface = { path = "../common/debug_interface" }
-failure = { package = "failure_ext", path = "../common/failure_ext" }
-generate_keypair = { path = "../config/generate_keypair" }
-libra_wallet = { path = "../client/libra_wallet" }
-libra_swarm = { path = "../libra_swarm" }
-logger = { path = "../common/logger" }
-metrics = { path = "../common/metrics" }
-proto_conv = { path = "../common/proto_conv" }
+admission_control_proto = { path = "../admission_control/admission_control_proto", package = "solana_libra_admission_control_proto" }
+client = { path = "../client", package = "solana_libra_client" }
+config = { path = "../config", package = "solana_libra_config" }
+crypto = { path = "../crypto/legacy_crypto", package = "solana_libra_crypto" }
+debug_interface = { path = "../common/debug_interface", package = "solana_libra_debug_interface" }
+failure = { path = "../common/failure_ext", package = "solana_libra_failure_ext" }
+generate_keypair = { path = "../config/generate_keypair", package = "solana_libra_generate_keypair" }
+libra_wallet = { path = "../client/libra_wallet", package = "solana_libra_wallet" }
+libra_swarm = { path = "../libra_swarm", package = "solana_libra_swarm" }
+logger = { path = "../common/logger", package = "solana_libra_logger" }
+metrics = { path = "../common/metrics", package = "solana_libra_metrics" }
+proto_conv = { path = "../common/proto_conv", package = "solana_libra_proto_conv" }
 rusty-fork = "0.2.1"
-types = { path = "../types" }
-vm_genesis = { path = "../language/vm/vm_genesis" }
+types = { path = "../types", package = "solana_libra_types" }
+vm_genesis = { path = "../language/vm/vm_genesis", package = "solana_libra_vm_genesis" }

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 bincode = "1.1.4"
 clap = "2.33.0"
 futures = "0.1.28"
-grpcio = "0.4"
+grpcio = { version = "0.4", default-features = false, features = ["protobuf-codec"] }
 itertools = "0.8.0"
 lazy_static = "1.2.0"
 protobuf = "2.7"

--- a/benchmark/src/bin/ruben.rs
+++ b/benchmark/src/bin/ruben.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use solana_libra_benchmark as benchmark;
+
 use admission_control_proto::proto::admission_control_grpc::AdmissionControlClient;
 use benchmark::{
     ruben_opt::{Executable, Opt},

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 bincode = "1.1.1"
 futures = "0.1.28"
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 hex = "0.3.2"
 hyper = "0.12.33"
 itertools = "0.8.0"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "client"
+name = "solana_libra_client"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -23,16 +23,16 @@ serde_json = "1.0.40"
 structopt = "0.2.15"
 tempfile = "3.1.0"
 
-admission_control_proto = { version = "0.1.0", path = "../admission_control/admission_control_proto" }
-config = { path = "../config" }
-crash_handler = { path = "../common/crash_handler" }
-crypto = { path = "../crypto/legacy_crypto" }
-nextgen_crypto = { path = "../crypto/nextgen_crypto" }
-failure = { package = "failure_ext", path = "../common/failure_ext" }
+admission_control_proto = { version = "0.1.0", path = "../admission_control/admission_control_proto", package = "solana_libra_admission_control_proto" }
+config = { path = "../config", package = "solana_libra_config" }
+crash_handler = { path = "../common/crash_handler", package = "solana_libra_crash_handler" }
+crypto = { path = "../crypto/legacy_crypto", package = "solana_libra_crypto" }
+nextgen_crypto = { path = "../crypto/nextgen_crypto", package = "solana_libra_nextgen_crypto" }
+failure = { path = "../common/failure_ext", package = "solana_libra_failure_ext" }
 libc = "0.2.60"
-libra_wallet = { path = "./libra_wallet" }
-logger =  { path = "../common/logger" }
-metrics = { path = "../common/metrics" }
-proto_conv = { path = "../common/proto_conv" }
-types = { path = "../types" }
-vm_genesis = { path = "../language/vm/vm_genesis" }
+libra_wallet = { path = "./libra_wallet", package = "solana_libra_wallet" }
+logger =  { path = "../common/logger", package = "solana_libra_logger" }
+metrics = { path = "../common/metrics", package = "solana_libra_metrics" }
+proto_conv = { path = "../common/proto_conv", package = "solana_libra_proto_conv" }
+types = { path = "../types", package = "solana_libra_types" }
+vm_genesis = { path = "../language/vm/vm_genesis", package = "solana_libra_vm_genesis" }

--- a/client/libra_wallet/Cargo.toml
+++ b/client/libra_wallet/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "libra_wallet"
+name = "solana_libra_wallet"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -23,17 +23,19 @@ version = "1.0.0-pre.1"
 
 [dependencies.types]
 path = "../../types"
+package = "solana_libra_types"
 
 [dependencies.libra_crypto]
 path = "../../crypto/legacy_crypto"
-package = "crypto"
+package = "solana_libra_crypto"
 
 [dependencies.proto_conv]
 path = "../../common/proto_conv"
+package = "solana_libra_proto_conv"
 
 [dependencies.failure]
 path = "../../common/failure_ext"
-package = "failure_ext"
+package = "solana_libra_failure_ext"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use solana_libra_client as client;
+
 use client::{client_proxy::ClientProxy, commands::*};
 use logger::set_default_global_logger;
 use rustyline::{config::CompletionType, error::ReadlineError, Config, Editor};

--- a/common/build_helpers/Cargo.toml
+++ b/common/build_helpers/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "build_helpers"
+name = "solana_libra_build_helpers"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -10,4 +10,4 @@ edition = "2018"
 protoc-grpcio = "0.3.1"
 walkdir = "2.2.8"
 
-grpcio-client = { path = "../grpcio-client" }
+grpcio-client = { path = "../grpcio-client", package = "solana_libra_grpcio-client" }

--- a/common/canonical_serialization/Cargo.toml
+++ b/common/canonical_serialization/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "canonical_serialization"
+name = "solana_libra_canonical_serialization"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 byteorder = "1.3.2"
 
-failure = { path = "../failure_ext", package = "failure_ext" }
+failure = { path = "../failure_ext", package = "solana_libra_failure_ext" }
 
 [dev-dependencies]
 hex = "0.3"

--- a/common/channel/Cargo.toml
+++ b/common/channel/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "channel"
+name = "solana_libra_channel"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 futures = { version = "=0.3.0-alpha.17", package = "futures-preview" }
 lazy_static = "1.3.0"
-metrics = { path = "../metrics" }
+metrics = { path = "../metrics", package = "solana_libra_metrics" }
 
 [dev-dependencies]
 rusty-fork = "0.2.1"

--- a/common/crash_handler/Cargo.toml
+++ b/common/crash_handler/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "crash_handler"
+name = "solana_libra_crash_handler"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -10,5 +10,5 @@ edition = "2018"
 backtrace = "0.3.33"
 toml = "0.4.7"
 
-logger = { path = "../logger" }
+logger = { path = "../logger", package = "solana_libra_logger" }
 serde = { version = "1.0.96", features = ["derive"] }

--- a/common/debug_interface/Cargo.toml
+++ b/common/debug_interface/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 futures = "0.1.28"
 protobuf = "2.7"
 

--- a/common/debug_interface/Cargo.toml
+++ b/common/debug_interface/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "debug_interface"
+name = "solana_libra_debug_interface"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -11,10 +11,10 @@ grpcio = "0.4.3"
 futures = "0.1.28"
 protobuf = "2.7"
 
-failure = { package = "failure_ext", path = "../failure_ext" }
-jemalloc = { path = "../jemalloc" }
-logger = { path = "../logger" }
-metrics = { path = "../metrics" }
+failure = { path = "../failure_ext", package = "solana_libra_failure_ext" }
+jemalloc = { path = "../jemalloc", package = "solana_libra_jemalloc" }
+logger = { path = "../logger", package = "solana_libra_logger" }
+metrics = { path = "../metrics", package = "solana_libra_metrics" }
 
 [build-dependencies]
-build_helpers = { path = "../build_helpers" }
+build_helpers = { path = "../build_helpers", package = "solana_libra_build_helpers" }

--- a/common/executable_helpers/Cargo.toml
+++ b/common/executable_helpers/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "executable_helpers"
+name = "solana_libra_executable_helpers"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -10,7 +10,7 @@ edition = "2018"
 clap = "2.32.0"
 slog-scope = "4.0"
 
-config = { path = "../../config" }
-crash_handler = { path = "../crash_handler" }
-logger =  { path = "../logger" }
-metrics = { path = "../metrics" }
+config = { path = "../../config", package = "solana_libra_config" }
+crash_handler = { path = "../crash_handler", package = "solana_libra_crash_handler" }
+logger =  { path = "../logger", package = "solana_libra_logger" }
+metrics = { path = "../metrics", package = "solana_libra_metrics" }

--- a/common/failure_ext/Cargo.toml
+++ b/common/failure_ext/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "failure_ext"
+name = "solana_libra_failure_ext"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -9,4 +9,4 @@ edition = "2018"
 [dependencies]
 failure = "0.1.3"
 
-failure_macros = { path = "failure_macros" }
+failure_macros = { path = "failure_macros", package = "solana_libra_failure_macros" }

--- a/common/failure_ext/failure_macros/Cargo.toml
+++ b/common/failure_ext/failure_macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "failure_macros"
+name = "solana_libra_failure_macros"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"

--- a/common/grpc_helpers/Cargo.toml
+++ b/common/grpc_helpers/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "grpc_helpers"
+name = "solana_libra_grpc_helpers"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -11,9 +11,9 @@ grpcio = "0.4.3"
 futures = { version = "0.3.0-alpha.13", package = "futures-preview", features = ["compat"] }
 futures_01 = { version = "0.1.25", package = "futures" }
 
-failure = { package = "failure_ext", path = "../failure_ext" }
-logger = { path = "../logger" }
-metrics = { path = "../metrics" }
+failure = { path = "../failure_ext", package = "solana_libra_failure_ext" }
+logger = { path = "../logger", package = "solana_libra_logger" }
+metrics = { path = "../metrics", package = "solana_libra_metrics" }
 
 [dependencies.prometheus]
 version  = "0.4.2"

--- a/common/grpc_helpers/Cargo.toml
+++ b/common/grpc_helpers/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 futures = { version = "0.3.0-alpha.13", package = "futures-preview", features = ["compat"] }
 futures_01 = { version = "0.1.25", package = "futures" }
 

--- a/common/grpcio-client/Cargo.toml
+++ b/common/grpcio-client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "grpcio-client"
+name = "solana_libra_grpcio-client"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"

--- a/common/grpcio-extras/Cargo.toml
+++ b/common/grpcio-extras/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 
 [dependencies]
 futures = "0.1.25"
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }

--- a/common/grpcio-extras/Cargo.toml
+++ b/common/grpcio-extras/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "grpcio-extras"
+name = "solana_libra_grpcio-extras"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"

--- a/common/jemalloc/Cargo.toml
+++ b/common/jemalloc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "jemalloc"
+name = "solana_libra_jemalloc"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "logger"
+name = "solana_libra_logger"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -29,7 +29,7 @@ tokio = "0.1.22"
 
 # Do NOT add any other inter-project dependencies.
 # This is to avoid ever having a circular dependency with the logger crate.
-failure = { package = "failure_ext", path = "../failure_ext" }
+failure = { path = "../failure_ext", package = "solana_libra_failure_ext" }
 
 [dev-dependencies]
 rand = "0.6.5"

--- a/common/metrics/Cargo.toml
+++ b/common/metrics/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.1.28"
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 hyper = "0.12.33"
 lazy_static = "1.3.0"
 protobuf = "2.7"

--- a/common/metrics/Cargo.toml
+++ b/common/metrics/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "metrics"
+name = "solana_libra_metrics"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -14,8 +14,8 @@ lazy_static = "1.3.0"
 protobuf = "2.7"
 serde_json = "1.0.40"
 
-failure = { path = "../failure_ext", package = "failure_ext" }
-logger = { path = "../logger" }
+failure = { path = "../failure_ext", package = "solana_libra_failure_ext" }
+logger = { path = "../logger", package = "solana_libra_logger" }
 
 [dependencies.prometheus]
 version  = "0.4.2"

--- a/common/proptest_helpers/Cargo.toml
+++ b/common/proptest_helpers/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "proptest_helpers"
+name = "solana_libra_proptest_helpers"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"

--- a/common/proto_conv/Cargo.toml
+++ b/common/proto_conv/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "proto_conv"
+name = "solana_libra_proto_conv"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -8,18 +8,18 @@ edition = "2018"
 
 [dependencies]
 protobuf = "2.7"
-failure = { path = "../failure_ext", package = "failure_ext" }
-proto_conv_derive = { path = "proto_conv_derive", optional = true }
+failure = { path = "../failure_ext", package = "solana_libra_failure_ext" }
+proto_conv_derive = { path = "proto_conv_derive", optional = true, package = "solana_libra_proto_conv_derive" }
 
 [dev-dependencies]
 proptest = "0.9.2"
 proptest-derive = "0.1.0"
 protobuf = "2.7"
 
-proto_conv = { path = ".", features = ["derive"] }
+proto_conv = { path = ".", features = ["derive"], package = "solana_libra_proto_conv" }
 
 [build-dependencies]
-build_helpers = { path = "../../common/build_helpers" }
+build_helpers = { path = "../../common/build_helpers", package = "solana_libra_build_helpers" }
 
 [features]
 default = []

--- a/common/proto_conv/proto_conv_derive/Cargo.toml
+++ b/common/proto_conv/proto_conv_derive/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "proto_conv_derive"
+name = "solana_libra_proto_conv_derive"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"

--- a/common/tools/Cargo.toml
+++ b/common/tools/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tools"
+name = "solana_libra_tools"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "config"
+name = "solana_libra_config"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -16,8 +16,8 @@ serde = { version = "1.0.96", features = ["derive"] }
 tempfile = "3.1.0"
 toml = "0.4"
 
-crypto = { path = "../crypto/legacy_crypto" }
-proto_conv = { path = "../common/proto_conv" }
-logger = { path = "../common/logger" }
-failure = { path = "../common/failure_ext", package = "failure_ext" }
-types = { path = "../types" }
+crypto = { path = "../crypto/legacy_crypto", package = "solana_libra_crypto" }
+proto_conv = { path = "../common/proto_conv", package = "solana_libra_proto_conv" }
+logger = { path = "../common/logger", package = "solana_libra_logger" }
+failure = { path = "../common/failure_ext", package = "solana_libra_failure_ext" }
+types = { path = "../types", package = "solana_libra_types" }

--- a/config/config_builder/Cargo.toml
+++ b/config/config_builder/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "config_builder"
+name = "solana_libra_config_builder"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -14,11 +14,11 @@ serde = { version = "1.0.96", features = ["derive"] }
 tempfile = "3.1.0"
 toml = "0.4"
 
-config = { path = ".." }
-crypto = { path = "../../crypto/legacy_crypto" }
-nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-generate_keypair = { path = "../generate_keypair" }
-proto_conv = { path = "../../common/proto_conv", features = ["derive"] }
-types = { path = "../../types" }
-vm_genesis = { path = "../../language/vm/vm_genesis" }
+config = { path = "..", package = "solana_libra_config" }
+crypto = { path = "../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+nextgen_crypto = { path = "../../crypto/nextgen_crypto", package = "solana_libra_nextgen_crypto" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+generate_keypair = { path = "../generate_keypair", package = "solana_libra_generate_keypair" }
+proto_conv = { path = "../../common/proto_conv", features = ["derive"], package = "solana_libra_proto_conv" }
+types = { path = "../../types", package = "solana_libra_types" }
+vm_genesis = { path = "../../language/vm/vm_genesis", package = "solana_libra_vm_genesis" }

--- a/config/config_builder/src/bin/libra-config.rs
+++ b/config/config_builder/src/bin/libra-config.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use solana_libra_config_builder as config_builder;
+
 use clap::{value_t, App, Arg};
 use config_builder::swarm_config::SwarmConfigBuilder;
 use std::convert::TryInto;

--- a/config/generate_keypair/Cargo.toml
+++ b/config/generate_keypair/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "generate_keypair"
+name = "solana_libra_generate_keypair"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -13,5 +13,5 @@ serde = { version = "1.0.96", features = ["derive"] }
 serde_json = "1.0.40"
 tempdir = "0.3.7"
 
-crypto = { path = "../../crypto/legacy_crypto" }
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
+crypto = { path = "../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }

--- a/config/generate_keypair/src/main.rs
+++ b/config/generate_keypair/src/main.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use solana_libra_generate_keypair as generate_keypair;
 use clap::{value_t, App, Arg};
 use generate_keypair::create_faucet_key_file;
 

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "consensus"
+name = "solana_libra_consensus"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -24,24 +24,24 @@ termion = "1.5.3"
 lazy_static = "1.3.0"
 rmp-serde = "0.13.7"
 
-canonical_serialization = { path = "../common/canonical_serialization" }
-channel = { path = "../common/channel" }
-config = { path = "../config" }
-crypto = { path = "../crypto/legacy_crypto" }
-nextgen_crypto = { path = "../crypto/nextgen_crypto" }
-execution_proto = { path = "../execution/execution_proto" }
-failure = { path = "../common/failure_ext", package = "failure_ext" }
-grpc_helpers = { path = "../common/grpc_helpers" }
-logger = { path = "../common/logger" }
-mempool = { path = "../mempool" }
-metrics = { path = "../common/metrics" }
-network = { path = "../network" }
-proto_conv = { path = "../common/proto_conv" }
-schemadb = { path = "../storage/schemadb" }
-storage_client = { path = "../storage/storage_client" }
-storage_proto = { path = "../storage/storage_proto" }
-tools = { path = "../common/tools" }
-types = { path = "../types" }
+canonical_serialization = { path = "../common/canonical_serialization", package = "solana_libra_canonical_serialization" }
+channel = { path = "../common/channel", package = "solana_libra_channel" }
+config = { path = "../config", package = "solana_libra_config" }
+crypto = { path = "../crypto/legacy_crypto", package = "solana_libra_crypto" }
+nextgen_crypto = { path = "../crypto/nextgen_crypto", package = "solana_libra_nextgen_crypto" }
+execution_proto = { path = "../execution/execution_proto", package = "solana_libra_execution_proto" }
+failure = { path = "../common/failure_ext", package = "solana_libra_failure_ext" }
+grpc_helpers = { path = "../common/grpc_helpers", package = "solana_libra_grpc_helpers" }
+logger = { path = "../common/logger", package = "solana_libra_logger" }
+mempool = { path = "../mempool", package = "solana_libra_mempool" }
+metrics = { path = "../common/metrics", package = "solana_libra_metrics" }
+network = { path = "../network", package = "solana_libra_network" }
+proto_conv = { path = "../common/proto_conv", package = "solana_libra_proto_conv" }
+schemadb = { path = "../storage/schemadb", package = "solana_libra_schemadb" }
+storage_client = { path = "../storage/storage_client", package = "solana_libra_storage_client" }
+storage_proto = { path = "../storage/storage_proto", package = "solana_libra_storage_proto" }
+tools = { path = "../common/tools", package = "solana_libra_tools" }
+types = { path = "../types", package = "solana_libra_types" }
 
 [dependencies.prometheus]
 version  = "0.4.2"
@@ -49,7 +49,7 @@ default-features = false
 features = ["push"]
 
 [build-dependencies]
-build_helpers = { path = "../common/build_helpers" }
+build_helpers = { path = "../common/build_helpers", package = "solana_libra_build_helpers" }
 
 [dev-dependencies]
 cached = "0.8.1"
@@ -57,16 +57,18 @@ tempfile = "3.1.0"
 parity-multiaddr = "0.4.0"
 rusty-fork = "0.2.1"
 
-config_builder = { path = "../config/config_builder" }
-execution_service = { path = "../execution/execution_service" }
-storage_service = { path = "../storage/storage_service" }
-vm_genesis = { path = "../language/vm/vm_genesis" }
-vm_validator = { path = "../vm_validator" }
+config_builder = { path = "../config/config_builder", package = "solana_libra_config_builder" }
+execution_service = { path = "../execution/execution_service", package = "solana_libra_execution_service" }
+storage_service = { path = "../storage/storage_service", package = "solana_libra_storage_service" }
+vm_genesis = { path = "../language/vm/vm_genesis", package = "solana_libra_vm_genesis" }
+vm_validator = { path = "../vm_validator", package = "solana_libra_vm_validator" }
 
 [dev-dependencies.nextgen_crypto]
 features = ["testing"]
 path = "../crypto/nextgen_crypto"
+package = "solana_libra_nextgen_crypto"
 
 [dev-dependencies.types]
 features = ["testing"]
 path = "../types"
+package = "solana_libra_types"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 byteorder = "1.3.2"
 bytes = "0.4.12"
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 futures = { version = "=0.3.0-alpha.17", package = "futures-preview", features = ["io-compat", "compat"] }
 futures_locks = { version = "=0.3.0", package = "futures-locks", features=["tokio"]}
 mirai-annotations = "^1.2.2"

--- a/crypto/legacy_crypto/Cargo.toml
+++ b/crypto/legacy_crypto/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "crypto"
+name = "solana_libra_crypto"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -27,9 +27,9 @@ hmac = "0.7.1"
 sha3 = "0.8.2"
 sha2 = "0.8.0"
 
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-crypto-derive = { path = "./src/macros" }
-proto_conv = { path = "../../common/proto_conv" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+crypto-derive = { path = "./src/macros", package = "solana_libra_crypto-derive" }
+proto_conv = { path = "../../common/proto_conv", package = "solana_libra_proto_conv" }
 
 [dev-dependencies]
 bitvec = "0.10.1"

--- a/crypto/legacy_crypto/src/macros/Cargo.toml
+++ b/crypto/legacy_crypto/src/macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "crypto-derive"
+name = "solana_libra_crypto-derive"
 version = "0.1.0"
 description = "Custom derives for `crypto`"
 edition = "2018"

--- a/crypto/nextgen_crypto/Cargo.toml
+++ b/crypto/nextgen_crypto/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "nextgen_crypto"
+name = "solana_libra_nextgen_crypto"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -28,10 +28,10 @@ hmac = "0.7.1"
 sha3 = "0.8.2"
 sha2 = "0.8.0"
 
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-crypto-derive = { path = "../legacy_crypto/src/macros" }
-proto_conv = { path = "../../common/proto_conv" }
-crypto = { path = "../legacy_crypto" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+crypto-derive = { path = "../legacy_crypto/src/macros", package = "solana_libra_crypto-derive" }
+proto_conv = { path = "../../common/proto_conv", package = "solana_libra_proto_conv" }
+crypto = { path = "../legacy_crypto", package = "solana_libra_crypto" }
 
 [dev-dependencies]
 bitvec = "0.10.1"

--- a/crypto/secret_service/Cargo.toml
+++ b/crypto/secret_service/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "secret_service"
+name = "solana_libra_secret_service"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -11,15 +11,15 @@ futures = "0.1.28"
 grpcio = "0.4.3"
 protobuf = "2.7"
 
-config = { path = "../../config" }
-grpc_helpers = { path = "../../common/grpc_helpers" }
-debug_interface = { path = "../../common/debug_interface" }
-failure = { package = "failure_ext", path = "../../common/failure_ext" }
-executable_helpers = { path = "../../common/executable_helpers" }
-logger = { path = "../../common/logger" }
+config = { path = "../../config", package = "solana_libra_config" }
+grpc_helpers = { path = "../../common/grpc_helpers", package = "solana_libra_grpc_helpers" }
+debug_interface = { path = "../../common/debug_interface", package = "solana_libra_debug_interface" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+executable_helpers = { path = "../../common/executable_helpers", package = "solana_libra_executable_helpers" }
+logger = { path = "../../common/logger", package = "solana_libra_logger" }
 
-nextgen_crypto = { path = "../nextgen_crypto" }
-crypto = { path = "../legacy_crypto" }
+nextgen_crypto = { path = "../nextgen_crypto", package = "solana_libra_nextgen_crypto" }
+crypto = { path = "../legacy_crypto", package = "solana_libra_crypto" }
 # ed25519-dalek = { version = "1.0.0-pre.1", features = ["serde"] }
 serde = { version = "1.0.96", features = ["derive"] }
 rand = "0.6.5"
@@ -27,7 +27,7 @@ rand_chacha = "0.1.1"
 
 derive_deref = "1.1.0"
 
-crypto-derive = { path = "../legacy_crypto/src/macros" }
+crypto-derive = { path = "../legacy_crypto/src/macros", package = "solana_libra_crypto-derive" }
 
 [build-dependencies]
-build_helpers = { path = "../../common/build_helpers" }
+build_helpers = { path = "../../common/build_helpers", package = "solana_libra_build_helpers" }

--- a/crypto/secret_service/Cargo.toml
+++ b/crypto/secret_service/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.1.28"
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 protobuf = "2.7"
 
 config = { path = "../../config", package = "solana_libra_config" }

--- a/crypto/secret_service/src/main.rs
+++ b/crypto/secret_service/src/main.rs
@@ -4,6 +4,7 @@
 use executable_helpers::helpers::{
     setup_executable, ARG_CONFIG_PATH, ARG_DISABLE_LOGGING, ARG_PEER_ID,
 };
+use solana_libra_secret_service as secret_service;
 use secret_service::secret_service_node;
 
 /// Run a SecretService in its own process.

--- a/execution/execution_client/Cargo.toml
+++ b/execution/execution_client/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-grpcio = "0.4.4"
+grpcio = { version = "0.4.4", default-features = false, features = ["protobuf-codec"] }
 
 execution_proto = { path = "../execution_proto", package = "solana_libra_execution_proto" }
 failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }

--- a/execution/execution_client/Cargo.toml
+++ b/execution/execution_client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "execution_client"
+name = "solana_libra_execution_client"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 grpcio = "0.4.4"
 
-execution_proto = { path = "../execution_proto" }
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-types = { path = "../../types" }
-proto_conv = { path = "../../common/proto_conv" }
+execution_proto = { path = "../execution_proto", package = "solana_libra_execution_proto" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+types = { path = "../../types", package = "solana_libra_types" }
+proto_conv = { path = "../../common/proto_conv", package = "solana_libra_proto_conv" }

--- a/execution/execution_proto/Cargo.toml
+++ b/execution/execution_proto/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.1.28"
-grpcio = "0.4.4"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 proptest = "0.9.2"
 proptest-derive = "0.1.0"
 protobuf = "2.7"

--- a/execution/execution_proto/Cargo.toml
+++ b/execution/execution_proto/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "execution_proto"
+name = "solana_libra_execution_proto"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -13,15 +13,16 @@ proptest = "0.9.2"
 proptest-derive = "0.1.0"
 protobuf = "2.7"
 
-crypto = { path = "../../crypto/legacy_crypto" }
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-proptest_helpers = { path = "../../common/proptest_helpers" }
-proto_conv = { path = "../../common/proto_conv", features = ["derive"] }
-types = { path = "../../types" }
+crypto = { path = "../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+proptest_helpers = { path = "../../common/proptest_helpers", package = "solana_libra_proptest_helpers" }
+proto_conv = { path = "../../common/proto_conv", features = ["derive"], package = "solana_libra_proto_conv" }
+types = { path = "../../types", package = "solana_libra_types" }
 
 [build-dependencies]
-build_helpers = { path = "../../common/build_helpers" }
+build_helpers = { path = "../../common/build_helpers", package = "solana_libra_build_helpers" }
 
 [dev-dependencies.types]
 features = ["testing"]
 path = "../../types"
+package = "solana_libra_types"

--- a/execution/execution_service/Cargo.toml
+++ b/execution/execution_service/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 futures01 = { package = "futures", version = "0.1.26" }
 futures03 = { package = "futures-preview", version = "=0.3.0-alpha.17", features = ["compat"] }
-grpcio = "0.4.4"
+grpcio = { version = "0.4.4", default-features = false, features = ["protobuf-codec"] }
 
 config = { path = "../../config", package = "solana_libra_config" }
 execution_proto = { path = "../execution_proto", package = "solana_libra_execution_proto" }

--- a/execution/execution_service/Cargo.toml
+++ b/execution/execution_service/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "execution_service"
+name = "solana_libra_execution_service"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -11,23 +11,23 @@ futures01 = { package = "futures", version = "0.1.26" }
 futures03 = { package = "futures-preview", version = "=0.3.0-alpha.17", features = ["compat"] }
 grpcio = "0.4.4"
 
-config = { path = "../../config" }
-execution_proto = { path = "../execution_proto" }
-executor = { path = "../executor" }
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-grpc_helpers = { path = "../../common/grpc_helpers" }
-proto_conv = { path = "../../common/proto_conv" }
-storage_client = { path = "../../storage/storage_client" }
-types = { path = "../../types" }
-vm_runtime = { path = "../../language/vm/vm_runtime" }
+config = { path = "../../config", package = "solana_libra_config" }
+execution_proto = { path = "../execution_proto", package = "solana_libra_execution_proto" }
+executor = { path = "../executor", package = "solana_libra_executor" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+grpc_helpers = { path = "../../common/grpc_helpers", package = "solana_libra_grpc_helpers" }
+proto_conv = { path = "../../common/proto_conv", package = "solana_libra_proto_conv" }
+storage_client = { path = "../../storage/storage_client", package = "solana_libra_storage_client" }
+types = { path = "../../types", package = "solana_libra_types" }
+vm_runtime = { path = "../../language/vm/vm_runtime", package = "solana_libra_vm_runtime" }
 
 [dev-dependencies]
 tempfile = "3.1.0"
 
-config = { path = "../../config" }
-config_builder = { path = "../../config/config_builder" }
-crypto = { path = "../../crypto/legacy_crypto" }
-execution_client = { path = "../execution_client" }
-storage_proto = { path = "../../storage/storage_proto" }
-storage_service = { path = "../../storage/storage_service" }
-vm_genesis = { path = "../../language/vm/vm_genesis" }
+config = { path = "../../config", package = "solana_libra_config" }
+config_builder = { path = "../../config/config_builder", package = "solana_libra_config_builder" }
+crypto = { path = "../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+execution_client = { path = "../execution_client", package = "solana_libra_execution_client" }
+storage_proto = { path = "../../storage/storage_proto", package = "solana_libra_storage_proto" }
+storage_service = { path = "../../storage/storage_service", package = "solana_libra_storage_service" }
+vm_genesis = { path = "../../language/vm/vm_genesis", package = "solana_libra_vm_genesis" }

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -27,7 +27,7 @@ vm_runtime = { path = "../../language/vm/vm_runtime", package = "solana_libra_vm
 vm_genesis = { path = "../../language/vm/vm_genesis", package = "solana_libra_vm_genesis" }
 
 [dev-dependencies]
-grpcio = "0.4.4"
+grpcio = { version = "0.4.4", default-features = false, features = ["protobuf-codec"] }
 proptest = "0.9.2"
 rusty-fork = "0.2.1"
 

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "executor"
+name = "solana_libra_executor"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -12,24 +12,24 @@ futures = { version = "=0.3.0-alpha.17", package = "futures-preview" }
 itertools = "0.8.0"
 lazy_static = "1.3.0"
 
-config = { path = "../../config" }
-crypto = { path = "../../crypto/legacy_crypto" }
-execution_proto = { path = "../execution_proto" }
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-logger = { path = "../../common/logger" }
-metrics = { path = "../../common/metrics" }
-proto_conv = { path = "../../common/proto_conv" }
-scratchpad = { path = "../../storage/scratchpad" }
-state_view = { path = "../../storage/state_view" }
-storage_client = { path = "../../storage/storage_client" }
-types = { path = "../../types" }
-vm_runtime = { path = "../../language/vm/vm_runtime" }
-vm_genesis = { path = "../../language/vm/vm_genesis" }
+config = { path = "../../config", package = "solana_libra_config" }
+crypto = { path = "../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+execution_proto = { path = "../execution_proto", package = "solana_libra_execution_proto" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+logger = { path = "../../common/logger", package = "solana_libra_logger" }
+metrics = { path = "../../common/metrics", package = "solana_libra_metrics" }
+proto_conv = { path = "../../common/proto_conv", package = "solana_libra_proto_conv" }
+scratchpad = { path = "../../storage/scratchpad", package = "solana_libra_scratchpad" }
+state_view = { path = "../../storage/state_view", package = "solana_libra_state_view" }
+storage_client = { path = "../../storage/storage_client", package = "solana_libra_storage_client" }
+types = { path = "../../types", package = "solana_libra_types" }
+vm_runtime = { path = "../../language/vm/vm_runtime", package = "solana_libra_vm_runtime" }
+vm_genesis = { path = "../../language/vm/vm_genesis", package = "solana_libra_vm_genesis" }
 
 [dev-dependencies]
 grpcio = "0.4.4"
 proptest = "0.9.2"
 rusty-fork = "0.2.1"
 
-storage_proto = { path = "../../storage/storage_proto" }
-storage_service = { path = "../../storage/storage_service" }
+storage_proto = { path = "../../storage/storage_proto", package = "solana_libra_storage_proto" }
+storage_service = { path = "../../storage/storage_service", package = "solana_libra_storage_service" }

--- a/language/bytecode_verifier/Cargo.toml
+++ b/language/bytecode_verifier/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bytecode_verifier"
+name = "solana_libra_bytecode_verifier"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -10,10 +10,10 @@ edition = "2018"
 mirai-annotations = "^1.2.2"
 petgraph = "0.4"
 
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-vm = { path = "../vm" }
-types = { path = "../../types" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+vm = { path = "../vm", package = "solana_libra_vm" }
+types = { path = "../../types", package = "solana_libra_types" }
 
 [dev-dependencies]
-invalid_mutations = { path = "invalid_mutations" }
+invalid_mutations = { path = "invalid_mutations", package = "solana_libra_invalid_mutations" }
 proptest = "0.9"

--- a/language/bytecode_verifier/invalid_mutations/Cargo.toml
+++ b/language/bytecode_verifier/invalid_mutations/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "invalid_mutations"
+name = "solana_libra_invalid_mutations"
 version = "0.1.0"
 edition = "2018"
 authors = ["Libra Association <opensource@libra.org>"]
@@ -8,5 +8,5 @@ publish = false
 
 [dependencies]
 proptest = "0.9"
-proptest_helpers = { path = "../../../common/proptest_helpers" }
-vm = { path = "../../vm" }
+proptest_helpers = { path = "../../../common/proptest_helpers", package = "solana_libra_proptest_helpers" }
+vm = { path = "../../vm", package = "solana_libra_vm" }

--- a/language/compiler/Cargo.toml
+++ b/language/compiler/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "compiler"
+name = "solana_libra_compiler"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -7,12 +7,12 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytecode_verifier = { path = "../bytecode_verifier" }
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-ir_to_bytecode = { path = "ir_to_bytecode" }
-stdlib = { path = "../stdlib" }
-types = { path = "../../types" }
-vm = { path = "../vm" }
+bytecode_verifier = { path = "../bytecode_verifier", package = "solana_libra_bytecode_verifier" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+ir_to_bytecode = { path = "ir_to_bytecode", package = "solana_libra_ir_to_bytecode" }
+stdlib = { path = "../stdlib", package = "solana_libra_stdlib" }
+types = { path = "../../types", package = "solana_libra_types" }
+vm = { path = "../vm", package = "solana_libra_vm" }
 log = "0.4.7"
 structopt = "0.2.15"
 serde_json = "1.0.40"

--- a/language/compiler/ir_to_bytecode/Cargo.toml
+++ b/language/compiler/ir_to_bytecode/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ir_to_bytecode"
+name = "solana_libra_ir_to_bytecode"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -7,10 +7,10 @@ publish = false
 edition = "2018"
 
 [dependencies]
-failure = { path = "../../../common/failure_ext", package = "failure_ext" }
-ir_to_bytecode_syntax = { path = "syntax" }
-types = { path = "../../../types" }
-vm = { path = "../../vm" }
+failure = { path = "../../../common/failure_ext", package = "solana_libra_failure_ext" }
+ir_to_bytecode_syntax = { path = "syntax", package = "solana_libra_ir_to_bytecode_syntax" }
+types = { path = "../../../types", package = "solana_libra_types" }
+vm = { path = "../../vm", package = "solana_libra_vm" }
 lalrpop-util = "0.16.3"
 log = "0.4.7"
 codespan = "0.1.3"

--- a/language/compiler/ir_to_bytecode/syntax/Cargo.toml
+++ b/language/compiler/ir_to_bytecode/syntax/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ir_to_bytecode_syntax"
+name = "solana_libra_ir_to_bytecode_syntax"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ codespan-reporting = "0.1.4"
 hex = "0.3.2"
 lalrpop-util = "0.16.3"
 regex = "1.1.9"
-types = { path = "../../../../types" }
+types = { path = "../../../../types", package = "solana_libra_types" }
 
 [build-dependencies]
 lalrpop = "0.16.3"

--- a/language/compiler/src/main.rs
+++ b/language/compiler/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use solana_libra_compiler as compiler;
+
 use bytecode_verifier::{
     verifier::{verify_module_dependencies, VerifiedProgram},
     VerifiedModule,

--- a/language/e2e_tests/Cargo.toml
+++ b/language/e2e_tests/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "language_e2e_tests"
+name = "solana_libra_language_e2e_tests"
 version = "0.1.0"
 edition = "2018"
 authors = ["Libra Association <opensource@libra.org>"]
@@ -7,25 +7,25 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-bytecode_verifier = { path = "../bytecode_verifier" }
-canonical_serialization = { path = "../../common/canonical_serialization" }
-crypto = { path = "../../crypto/legacy_crypto"}
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-compiler = { path = "../compiler"}
-ir_to_bytecode = { path = "../compiler/ir_to_bytecode" }
+bytecode_verifier = { path = "../bytecode_verifier", package = "solana_libra_bytecode_verifier" }
+canonical_serialization = { path = "../../common/canonical_serialization", package = "solana_libra_canonical_serialization" }
+crypto = { path = "../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+compiler = { path = "../compiler", package = "solana_libra_compiler" }
+ir_to_bytecode = { path = "../compiler/ir_to_bytecode", package = "solana_libra_ir_to_bytecode" }
 lazy_static = "1.3.0"
-state_view = { path = "../../storage/state_view" }
-types = { path = "../../types" }
-vm = { path = "../vm" }
-vm_runtime = { path = "../vm/vm_runtime" }
+state_view = { path = "../../storage/state_view", package = "solana_libra_state_view" }
+types = { path = "../../types", package = "solana_libra_types" }
+vm = { path = "../vm", package = "solana_libra_vm" }
+vm_runtime = { path = "../vm/vm_runtime", package = "solana_libra_vm_runtime" }
 proptest = "0.9.3"
 proptest-derive = "0.1.1"
 assert_matches = "1.3.0"
-proptest_helpers = { path = "../../common/proptest_helpers" }
+proptest_helpers = { path = "../../common/proptest_helpers", package = "solana_libra_proptest_helpers" }
 protobuf = "2.7"
-proto_conv = { path = "../../common/proto_conv", features = ["derive"] }
+proto_conv = { path = "../../common/proto_conv", features = ["derive"], package = "solana_libra_proto_conv" }
 tiny-keccak = "1.5.0"
-vm_genesis = { path = "../vm/vm_genesis"}
-config =  { path = "../../config"}
-logger = { path = "../../common/logger" }
-stdlib = { path = "../stdlib" }
+vm_genesis = { path = "../vm/vm_genesis", package = "solana_libra_vm_genesis" }
+config =  { path = "../../config", package = "solana_libra_config" }
+logger = { path = "../../common/logger", package = "solana_libra_logger" }
+stdlib = { path = "../stdlib", package = "solana_libra_stdlib" }

--- a/language/functional_tests/Cargo.toml
+++ b/language/functional_tests/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
-name = "functional_tests"
+name = "solana_libra_functional_tests"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-ir_to_bytecode = { path = "../compiler/ir_to_bytecode" }
-stdlib = { path = "../stdlib" }
-types = { path = "../../types" }
-vm = { path = "../vm" }
-bytecode_verifier = { path = "../bytecode_verifier" }
-language_e2e_tests = { path = "../e2e_tests" }
-config = { path = "../../config" }
-transaction_builder = { path = "../transaction_builder" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+ir_to_bytecode = { path = "../compiler/ir_to_bytecode", package = "solana_libra_ir_to_bytecode" }
+stdlib = { path = "../stdlib", package = "solana_libra_stdlib" }
+types = { path = "../../types", package = "solana_libra_types" }
+vm = { path = "../vm", package = "solana_libra_vm" }
+bytecode_verifier = { path = "../bytecode_verifier", package = "solana_libra_bytecode_verifier" }
+language_e2e_tests = { path = "../e2e_tests", package = "solana_libra_language_e2e_tests" }
+config = { path = "../../config", package = "solana_libra_config" }
+transaction_builder = { path = "../transaction_builder", package = "solana_libra_transaction_builder" }
 termcolor = "1.0.4"
 filecheck = "0.4.0"
 datatest = "0.3.5"

--- a/language/stackless_bytecode_generator/Cargo.toml
+++ b/language/stackless_bytecode_generator/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "stackless_bytecode_generator"
+name = "solana_libra_stackless_bytecode_generator"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -7,11 +7,11 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytecode_verifier = { path = "../bytecode_verifier" }
-vm = { path = "../vm" }
-types = { path = "../../types" }
-ir_to_bytecode = { path = "../compiler/ir_to_bytecode"}
+bytecode_verifier = { path = "../bytecode_verifier", package = "solana_libra_bytecode_verifier" }
+vm = { path = "../vm", package = "solana_libra_vm" }
+types = { path = "../../types", package = "solana_libra_types" }
+ir_to_bytecode = { path = "../compiler/ir_to_bytecode", package = "solana_libra_ir_to_bytecode" }
 #
 [dev-dependencies]
-# invalid_mutations = { path = "invalid_mutations" }
+# invalid_mutations = { path = "invalid_mutations", package = "solana_libra_invalid_mutations" }
 proptest = "0.9"

--- a/language/stdlib/Cargo.toml
+++ b/language/stdlib/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "stdlib"
+name = "solana_libra_stdlib"
 version = "0.1.0"
 edition = "2018"
 authors = ["Libra Association <opensource@libra.org>"]
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-bytecode_verifier = { path = "../bytecode_verifier" }
-ir_to_bytecode = { path = "../compiler/ir_to_bytecode" }
-types = { path = "../../types" }
+bytecode_verifier = { path = "../bytecode_verifier", package = "solana_libra_bytecode_verifier" }
+ir_to_bytecode = { path = "../compiler/ir_to_bytecode", package = "solana_libra_ir_to_bytecode" }
+types = { path = "../../types", package = "solana_libra_types" }
 lazy_static = "1.3.0"

--- a/language/stdlib/natives/Cargo.toml
+++ b/language/stdlib/natives/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "move_ir_natives"
+name = "solana_libra_move_ir_natives"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -8,8 +8,8 @@ edition = "2018"
 
 [dependencies]
 bitcoin_hashes = "0.3.0"
-nextgen_crypto = { path = "../../../crypto/nextgen_crypto" }
-failure = { path = "../../../common/failure_ext", package = "failure_ext" }
+nextgen_crypto = { path = "../../../crypto/nextgen_crypto", package = "solana_libra_nextgen_crypto" }
+failure = { path = "../../../common/failure_ext", package = "solana_libra_failure_ext" }
 tiny-keccak = "1.5.0"
-types = { path = "../../../types" }
+types = { path = "../../../types", package = "solana_libra_types" }
 byteorder = "1.3.2"

--- a/language/tools/cost_synthesis/Cargo.toml
+++ b/language/tools/cost_synthesis/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cost_synthesis"
+name = "solana_libra_cost_synthesis"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -11,17 +11,17 @@ csv = "1.1.1"
 rand = "0.6.5"
 lazy_static = "1.3.0"
 
-bytecode_verifier = { path = "../../bytecode_verifier" }
-failure = { path = "../../../common/failure_ext", package = "failure_ext" }
-stdlib = { path = "../../stdlib" }
-types = { path = "../../../types" }
-vm = { path = "../../vm" }
-vm_runtime = { path = "../../vm/vm_runtime" }
-language_e2e_tests = { path = "../../e2e_tests" }
-vm_cache_map = { path = "../../vm/vm_runtime/vm_cache_map" }
-move_ir_natives = { path = "../../stdlib/natives" }
-crypto = { path = "../../../crypto/legacy_crypto" }
-state_view = { path = "../../../storage/state_view" }
+bytecode_verifier = { path = "../../bytecode_verifier", package = "solana_libra_bytecode_verifier" }
+failure = { path = "../../../common/failure_ext", package = "solana_libra_failure_ext" }
+stdlib = { path = "../../stdlib", package = "solana_libra_stdlib" }
+types = { path = "../../../types", package = "solana_libra_types" }
+vm = { path = "../../vm", package = "solana_libra_vm" }
+vm_runtime = { path = "../../vm/vm_runtime", package = "solana_libra_vm_runtime" }
+language_e2e_tests = { path = "../../e2e_tests", package = "solana_libra_language_e2e_tests" }
+vm_cache_map = { path = "../../vm/vm_runtime/vm_cache_map", package = "solana_libra_vm_cache_map" }
+move_ir_natives = { path = "../../stdlib/natives", package = "solana_libra_move_ir_natives" }
+crypto = { path = "../../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+state_view = { path = "../../../storage/state_view", package = "solana_libra_state_view" }
 
 [features]
 default = ["vm_runtime/instruction_synthesis"]

--- a/language/tools/cost_synthesis/src/bin/main.rs
+++ b/language/tools/cost_synthesis/src/bin/main.rs
@@ -6,6 +6,9 @@
 //! * Global-memory independent instructions;
 //! * Global-memory dependent instructions; and
 //! * Native operations.
+
+use solana_libra_cost_synthesis as cost_synthesis;
+
 use cost_synthesis::{
     global_state::{account::Account, inhabitor::RandomInhabitor},
     module_generator::ModuleGenerator,

--- a/language/tools/repl/Cargo.toml
+++ b/language/tools/repl/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "repl"
+name = "solana_libra_repl"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -7,12 +7,12 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytecode_verifier = { path = "../../bytecode_verifier" }
-compiler = { path = "../../compiler" }
-failure = { path = "../../../common/failure_ext", package = "failure_ext" }
+bytecode_verifier = { path = "../../bytecode_verifier", package = "solana_libra_bytecode_verifier" }
+compiler = { path = "../../compiler", package = "solana_libra_compiler" }
+failure = { path = "../../../common/failure_ext", package = "solana_libra_failure_ext" }
 getopts = "0.2.18"
-language_e2e_tests = { path = "../../e2e_tests" }
-stdlib = { path = "../../stdlib" }
-types = { path = "../../../types" }
-vm_runtime = { path = "../../vm/vm_runtime" }
+language_e2e_tests = { path = "../../e2e_tests", package = "solana_libra_language_e2e_tests" }
+stdlib = { path = "../../stdlib", package = "solana_libra_stdlib" }
+types = { path = "../../../types", package = "solana_libra_types" }
+vm_runtime = { path = "../../vm/vm_runtime", package = "solana_libra_vm_runtime" }
 hex = "0.3.2"

--- a/language/transaction_builder/Cargo.toml
+++ b/language/transaction_builder/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name = "transaction_builder"
+name = "solana_libra_transaction_builder"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-types = { path = "../../types" }
-vm = { path = "../vm" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+types = { path = "../../types", package = "solana_libra_types" }
+vm = { path = "../vm", package = "solana_libra_vm" }
 hex = "0.3.2"
 structopt = { version = "0.2.15", optional = true }
 serde_json = { version = "1.0.40", optional = true }
-proto_conv = { path = "../../common/proto_conv", optional = true }
+proto_conv = { path = "../../common/proto_conv", optional = true, package = "solana_libra_proto_conv" }
 
 [features]
 build-binary = ["structopt", "serde_json", "proto_conv"]
 
 [[bin]]
-name = "transaction_builder"
+name = "solana_libra_transaction_builder"
 path = "src/bin/main.rs"
 required-features = ["build-binary"]

--- a/language/vm/Cargo.toml
+++ b/language/vm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "vm"
+name = "solana_libra_vm"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -12,10 +12,10 @@ hex = "0.3.2"
 proptest = "0.9"
 proptest-derive = "0.1.1"
 lazy_static = "1.3.0"
-crypto = { path = "../../crypto/legacy_crypto" }
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-proptest_helpers = { path = "../../common/proptest_helpers" }
-types = { path = "../../types" }
+crypto = { path = "../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+proptest_helpers = { path = "../../common/proptest_helpers", package = "solana_libra_proptest_helpers" }
+types = { path = "../../types", package = "solana_libra_types" }
 mirai-annotations = "^1.2.2"
 
 [features]

--- a/language/vm/vm_genesis/Cargo.toml
+++ b/language/vm/vm_genesis/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "vm_genesis"
+name = "solana_libra_vm_genesis"
 version = "0.1.0"
 edition = "2018"
 authors = ["Libra Association <opensource@libra.org>"]
@@ -7,17 +7,17 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-config = { path = "../../../config" }
-crypto = { path = "../../../crypto/legacy_crypto" }
-failure = { path = "../../../common/failure_ext", package = "failure_ext" }
-ir_to_bytecode = { path = "../../compiler/ir_to_bytecode" }
-stdlib = { path = "../../stdlib" }
-proto_conv = { path = "../../../common/proto_conv", features = ["derive"] }
-state_view = { path = "../../../storage/state_view" }
-types = { path = "../../../types" }
-vm = { path = "../" }
-vm_cache_map = { path = "../vm_runtime/vm_cache_map" }
-vm_runtime = { path = "../vm_runtime" }
+config = { path = "../../../config", package = "solana_libra_config" }
+crypto = { path = "../../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+failure = { path = "../../../common/failure_ext", package = "solana_libra_failure_ext" }
+ir_to_bytecode = { path = "../../compiler/ir_to_bytecode", package = "solana_libra_ir_to_bytecode" }
+stdlib = { path = "../../stdlib", package = "solana_libra_stdlib" }
+proto_conv = { path = "../../../common/proto_conv", features = ["derive"], package = "solana_libra_proto_conv" }
+state_view = { path = "../../../storage/state_view", package = "solana_libra_state_view" }
+types = { path = "../../../types", package = "solana_libra_types" }
+vm = { path = "../", package = "solana_libra_vm" }
+vm_cache_map = { path = "../vm_runtime/vm_cache_map", package = "solana_libra_vm_cache_map" }
+vm_runtime = { path = "../vm_runtime", package = "solana_libra_vm_runtime" }
 hex = "0.3.2"
 lazy_static = "1.3.0"
 rand = "0.6.5"
@@ -25,11 +25,12 @@ tiny-keccak = "1.5.0"
 toml = "0.4"
 
 [dev-dependencies]
-canonical_serialization = { path = "../../../common/canonical_serialization" }
+canonical_serialization = { path = "../../../common/canonical_serialization", package = "solana_libra_canonical_serialization" }
 proptest = "0.9.3"
 proptest-derive = "0.1.1"
-proptest_helpers = { path = "../../../common/proptest_helpers" }
+proptest_helpers = { path = "../../../common/proptest_helpers", package = "solana_libra_proptest_helpers" }
 
 [dev-dependencies.types]
 features = ["testing"]
 path = "../../../types"
+package = "solana_libra_types"

--- a/language/vm/vm_genesis/src/main.rs
+++ b/language/vm/vm_genesis/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use solana_libra_vm_genesis as vm_genesis;
+
 use std::{fs::File, io::prelude::*};
 use vm_genesis::{default_config, encode_genesis_transaction, GENESIS_KEYPAIR};
 

--- a/language/vm/vm_runtime/Cargo.toml
+++ b/language/vm/vm_runtime/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "vm_runtime"
+name = "solana_libra_vm_runtime"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -12,20 +12,20 @@ tiny-keccak = "1.5.0"
 proptest = "0.9"
 rayon = "1.1"
 
-bytecode_verifier = { path = "../../bytecode_verifier" }
-canonical_serialization = { path = "../../../common/canonical_serialization" }
-crypto = { path = "../../../crypto/legacy_crypto"}
-failure = { path = "../../../common/failure_ext", package = "failure_ext" }
-metrics = { path = "../../../common/metrics" }
-state_view = { path = "../../../storage/state_view" }
-types = { path = "../../../types" }
-vm = { path = "../" }
-vm_cache_map = { path = "vm_cache_map" }
+bytecode_verifier = { path = "../../bytecode_verifier", package = "solana_libra_bytecode_verifier" }
+canonical_serialization = { path = "../../../common/canonical_serialization", package = "solana_libra_canonical_serialization" }
+crypto = { path = "../../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+failure = { path = "../../../common/failure_ext", package = "solana_libra_failure_ext" }
+metrics = { path = "../../../common/metrics", package = "solana_libra_metrics" }
+state_view = { path = "../../../storage/state_view", package = "solana_libra_state_view" }
+types = { path = "../../../types", package = "solana_libra_types" }
+vm = { path = "../", package = "solana_libra_vm" }
+vm_cache_map = { path = "vm_cache_map", package = "solana_libra_vm_cache_map" }
 lazy_static = "1.3.0"
-move_ir_natives = { path = "../../stdlib/natives" }
+move_ir_natives = { path = "../../stdlib/natives", package = "solana_libra_move_ir_natives" }
 hex = "0.3.2"
-config = { path = "../../../config"}
-logger = { path = "../../../common/logger" }
+config = { path = "../../../config", package = "solana_libra_config" }
+logger = { path = "../../../common/logger", package = "solana_libra_logger" }
 
 [dependencies.prometheus]
 version  = "0.4.2"
@@ -34,7 +34,7 @@ features = ["push"]
 
 [dev-dependencies]
 assert_matches = "1.3.0"
-compiler = { path = "../../compiler"}
+compiler = { path = "../../compiler", package = "solana_libra_compiler" }
 
 [features]
 instruction_synthesis = []

--- a/language/vm/vm_runtime/vm_cache_map/Cargo.toml
+++ b/language/vm/vm_runtime/vm_cache_map/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "vm_cache_map"
+name = "solana_libra_vm_cache_map"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"

--- a/libra_node/Cargo.toml
+++ b/libra_node/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 grpcio-sys = "0.4.4"
 signal-hook = "0.1.10"
 tokio = "0.1.22"

--- a/libra_node/Cargo.toml
+++ b/libra_node/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "libra_node"
+name = "solana_libra_node"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -12,28 +12,28 @@ grpcio-sys = "0.4.4"
 signal-hook = "0.1.10"
 tokio = "0.1.22"
 
-admission_control_proto = { path = "../admission_control/admission_control_proto" }
-admission_control_service = { path = "../admission_control/admission_control_service" }
-config = { path = "../config" }
-consensus = { path = "../consensus" }
-crash_handler = { path = "../common/crash_handler" }
-crypto = { path = "../crypto/legacy_crypto" }
-debug_interface = { path = "../common/debug_interface" }
-logger = { path = "../common/logger" }
-executable_helpers = { path = "../common/executable_helpers" }
-execution_proto = { path = "../execution/execution_proto" }
-grpc_helpers = { path = "../common/grpc_helpers" }
-mempool = { path = "../mempool" }
-metrics = { path = "../common/metrics" }
-execution_service = { path = "../execution/execution_service" }
-failure = { path = "../common/failure_ext", package = "failure_ext" }
-network = { path = "../network" }
-proto_conv = { path = "../common/proto_conv" }
-storage_client = { path = "../storage/storage_client" }
-storage_service = { path = "../storage/storage_service" }
-types = { path = "../types" }
-vm_genesis = { path = "../language/vm/vm_genesis" }
-vm_validator = { path = "../vm_validator" }
+admission_control_proto = { path = "../admission_control/admission_control_proto", package = "solana_libra_admission_control_proto" }
+admission_control_service = { path = "../admission_control/admission_control_service", package = "solana_libra_admission_control_service" }
+config = { path = "../config", package = "solana_libra_config" }
+consensus = { path = "../consensus", package = "solana_libra_consensus" }
+crash_handler = { path = "../common/crash_handler", package = "solana_libra_crash_handler" }
+crypto = { path = "../crypto/legacy_crypto", package = "solana_libra_crypto" }
+debug_interface = { path = "../common/debug_interface", package = "solana_libra_debug_interface" }
+logger = { path = "../common/logger", package = "solana_libra_logger" }
+executable_helpers = { path = "../common/executable_helpers", package = "solana_libra_executable_helpers" }
+execution_proto = { path = "../execution/execution_proto", package = "solana_libra_execution_proto" }
+grpc_helpers = { path = "../common/grpc_helpers", package = "solana_libra_grpc_helpers" }
+mempool = { path = "../mempool", package = "solana_libra_mempool" }
+metrics = { path = "../common/metrics", package = "solana_libra_metrics" }
+execution_service = { path = "../execution/execution_service", package = "solana_libra_execution_service" }
+failure = { path = "../common/failure_ext", package = "solana_libra_failure_ext" }
+network = { path = "../network", package = "solana_libra_network" }
+proto_conv = { path = "../common/proto_conv", package = "solana_libra_proto_conv" }
+storage_client = { path = "../storage/storage_client", package = "solana_libra_storage_client" }
+storage_service = { path = "../storage/storage_service", package = "solana_libra_storage_service" }
+types = { path = "../types", package = "solana_libra_types" }
+vm_genesis = { path = "../language/vm/vm_genesis", package = "solana_libra_vm_genesis" }
+vm_validator = { path = "../vm_validator", package = "solana_libra_vm_validator" }
 
 [dev-dependencies]
-config_builder = { path = "../config/config_builder" }
+config_builder = { path = "../config/config_builder", package = "solana_libra_config_builder" }

--- a/libra_node/src/main.rs
+++ b/libra_node/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use solana_libra_node as libra_node;
+
 use executable_helpers::helpers::{
     setup_executable, ARG_CONFIG_PATH, ARG_DISABLE_LOGGING, ARG_PEER_ID,
 };

--- a/libra_swarm/Cargo.toml
+++ b/libra_swarm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "libra_swarm"
+name = "solana_libra_swarm"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -14,12 +14,12 @@ lazy_static = "1.2.0"
 structopt = "0.2.15"
 tempfile = "3.1.0"
 
-client_lib = { package = "client", path = "../client" }
-config = { path = "../config" }
-config_builder = { path = "../config/config_builder" }
-crypto = { path = "../crypto/legacy_crypto" }
-debug_interface = { path = "../common/debug_interface" }
-failure = { path = "../common/failure_ext", package = "failure_ext" }
-generate_keypair = { path = "../config/generate_keypair" }
-logger = { path = "../common/logger" }
-tools = { path = "../common/tools" }
+client_lib = { path = "../client", package = "solana_libra_client" }
+config = { path = "../config", package = "solana_libra_config" }
+config_builder = { path = "../config/config_builder", package = "solana_libra_config_builder" }
+crypto = { path = "../crypto/legacy_crypto", package = "solana_libra_crypto" }
+debug_interface = { path = "../common/debug_interface", package = "solana_libra_debug_interface" }
+failure = { path = "../common/failure_ext", package = "solana_libra_failure_ext" }
+generate_keypair = { path = "../config/generate_keypair", package = "solana_libra_generate_keypair" }
+logger = { path = "../common/logger", package = "solana_libra_logger" }
+tools = { path = "../common/tools", package = "solana_libra_tools" }

--- a/libra_swarm/Cargo.toml
+++ b/libra_swarm/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 bincode = "1.1.1"
 ctrlc = "3.1.3"
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 lazy_static = "1.2.0"
 structopt = "0.2.15"
 tempfile = "3.1.0"

--- a/libra_swarm/src/main.rs
+++ b/libra_swarm/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use solana_libra_swarm as libra_swarm;
+
 use libra_swarm::{client, swarm::LibraSwarm};
 use std::path::Path;
 use structopt::StructOpt;

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 chrono = "0.4.7"
 futures = "0.1.28"
 futures-preview = { version = "=0.3.0-alpha.17", package = "futures-preview", features = ["compat"] }
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 grpcio-sys = "0.4.4"
 lazy_static = "1.3.0"
 lru-cache = "0.1.1"

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mempool"
+name = "solana_libra_mempool"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -18,24 +18,24 @@ protobuf = "2.7"
 tokio = "0.1.22"
 ttl_cache = "0.4.2"
 
-config = { path = "../config" }
-crypto = { path = "../crypto/legacy_crypto" }
-failure = { path = "../common/failure_ext", package = "failure_ext" }
-grpc_helpers = { path = "../common/grpc_helpers" }
-logger = { path = "../common/logger" }
-metrics = { path = "../common/metrics" }
-network = { path = "../network" }
-proto_conv = { path = "../common/proto_conv" }
-storage_client = { path = "../storage/storage_client" }
-types = { path = "../types" }
-vm_validator = { path = "../vm_validator" }
+config = { path = "../config", package = "solana_libra_config" }
+crypto = { path = "../crypto/legacy_crypto", package = "solana_libra_crypto" }
+failure = { path = "../common/failure_ext", package = "solana_libra_failure_ext" }
+grpc_helpers = { path = "../common/grpc_helpers", package = "solana_libra_grpc_helpers" }
+logger = { path = "../common/logger", package = "solana_libra_logger" }
+metrics = { path = "../common/metrics", package = "solana_libra_metrics" }
+network = { path = "../network", package = "solana_libra_network" }
+proto_conv = { path = "../common/proto_conv", package = "solana_libra_proto_conv" }
+storage_client = { path = "../storage/storage_client", package = "solana_libra_storage_client" }
+types = { path = "../types", package = "solana_libra_types" }
+vm_validator = { path = "../vm_validator", package = "solana_libra_vm_validator" }
 
 [dev-dependencies]
 rand = "0.6.5"
 tempfile = "3.1.0"
-channel = { path = "../common/channel" }
+channel = { path = "../common/channel", package = "solana_libra_channel" }
 
-storage_service = { path = "../storage/storage_service" }
+storage_service = { path = "../storage/storage_service", package = "solana_libra_storage_service" }
 
 [build-dependencies]
-build_helpers = { path = "../common/build_helpers" }
+build_helpers = { path = "../common/build_helpers", package = "solana_libra_build_helpers" }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "network"
+name = "solana_libra_network"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -20,17 +20,17 @@ tokio-timer = "0.2.10"
 tokio-retry = "0.2.0"
 unsigned-varint = { version = "0.2.2", features = ["codec"] }
 
-channel = { path = "../common/channel" }
-crypto = { path = "../crypto/legacy_crypto" }
-nextgen_crypto = { path = "../crypto/nextgen_crypto" }
-failure = { package = "failure_ext", path = "../common/failure_ext" }
-logger = { path = "../common/logger" }
-memsocket = { path = "memsocket" }
-metrics = { path = "../common/metrics" }
-netcore = { path = "netcore" }
-noise = { path = "noise" }
-socket_bench_server = { path = "socket_bench_server" }
-types = { path = "../types" }
+channel = { path = "../common/channel", package = "solana_libra_channel" }
+crypto = { path = "../crypto/legacy_crypto", package = "solana_libra_crypto" }
+nextgen_crypto = { path = "../crypto/nextgen_crypto", package = "solana_libra_nextgen_crypto" }
+failure = { path = "../common/failure_ext", package = "solana_libra_failure_ext" }
+logger = { path = "../common/logger", package = "solana_libra_logger" }
+memsocket = { path = "memsocket", package = "solana_libra_memsocket" }
+metrics = { path = "../common/metrics", package = "solana_libra_metrics" }
+netcore = { path = "netcore", package = "solana_libra_netcore" }
+noise = { path = "noise", package = "solana_libra_noise" }
+socket_bench_server = { path = "socket_bench_server", package = "solana_libra_socket_bench_server" }
+types = { path = "../types", package = "solana_libra_types" }
 
 [dev-dependencies]
 criterion = "0.2.11"
@@ -38,14 +38,17 @@ criterion = "0.2.11"
 [dev-dependencies.nextgen_crypto]
 features = ["testing"]
 path = "../crypto/nextgen_crypto"
+package = "solana_libra_nextgen_crypto"
 
 [build-dependencies]
 protoc-rust = "2.5.0"
 
 [[bench]]
-name = "socket_muxer_bench"
+name = "solana_libra_socket_muxer_bench"
+path = "benches/socket_muxer_bench.rs"
 harness = false
 
 [[bench]]
-name = "network_bench"
+name = "solana_libra_network_bench"
+path = "benches/network_bench.rs"
 harness = false

--- a/network/memsocket/Cargo.toml
+++ b/network/memsocket/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "memsocket"
+name = "solana_libra_memsocket"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"

--- a/network/netcore/Cargo.toml
+++ b/network/netcore/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "netcore"
+name = "solana_libra_netcore"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -15,4 +15,4 @@ tokio = "0.1.22"
 yamux = "0.2.1"
 parity-multiaddr = "0.4.0"
 
-memsocket = { path = "../memsocket" }
+memsocket = { path = "../memsocket", package = "solana_libra_memsocket" }

--- a/network/noise/Cargo.toml
+++ b/network/noise/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "noise"
+name = "solana_libra_noise"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -10,9 +10,9 @@ edition = "2018"
 futures = { version = "=0.3.0-alpha.17", package = "futures-preview" }
 snow = { version = "0.5.2", features=["ring-accelerated"]}
 
-crypto = { path = "../../crypto/legacy_crypto" }
-netcore = { path = "../netcore" }
-logger = { path = "../../common/logger" }
+crypto = { path = "../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+netcore = { path = "../netcore", package = "solana_libra_netcore" }
+logger = { path = "../../common/logger", package = "solana_libra_logger" }
 
 [dev-dependencies]
-memsocket = { path = "../memsocket" }
+memsocket = { path = "../memsocket", package = "solana_libra_memsocket" }

--- a/network/socket_bench_server/Cargo.toml
+++ b/network/socket_bench_server/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "socket_bench_server"
+name = "solana_libra_socket_bench_server"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -15,8 +15,8 @@ structopt = "0.2.15"
 tokio = "0.1.22"
 unsigned-varint = { version = "0.2.2", features = ["codec"] }
 
-failure = { package = "failure_ext", path = "../../common/failure_ext" }
-logger = { path = "../../common/logger" }
-memsocket = { path = "../memsocket" }
-netcore = { path = "../netcore" }
-noise = { path = "../noise" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+logger = { path = "../../common/logger", package = "solana_libra_logger" }
+memsocket = { path = "../memsocket", package = "solana_libra_memsocket" }
+netcore = { path = "../netcore", package = "solana_libra_netcore" }
+noise = { path = "../noise", package = "solana_libra_noise" }

--- a/network/socket_bench_server/src/main.rs
+++ b/network/socket_bench_server/src/main.rs
@@ -19,6 +19,7 @@
 use futures_01::future::Future as Future01;
 use logger::{prelude::*, set_default_global_logger};
 use netcore::transport::tcp::TcpTransport;
+use solana_libra_socket_bench_server as socket_bench_server;
 use socket_bench_server::{
     build_tcp_muxer_transport, build_tcp_noise_muxer_transport, build_tcp_noise_transport,
     start_muxer_server, start_stream_server, Args,

--- a/storage/accumulator/Cargo.toml
+++ b/storage/accumulator/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "accumulator"
+name = "solana_libra_accumulator"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -9,9 +9,9 @@ edition = "2018"
 [dependencies]
 proptest = "0.9.1"
 
-crypto = { path = "../../crypto/legacy_crypto" }
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-types = { path = "../../types" }
+crypto = { path = "../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+types = { path = "../../types", package = "solana_libra_types" }
 
 [dev-dependencies]
 rand = "0.6.5"

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "libradb"
+name = "solana_libradb"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -19,17 +19,17 @@ strum = "0.15.0"
 strum_macros = "0.15.0"
 tempfile = "3.0.6"
 
-accumulator = { path = "../accumulator" }
-canonical_serialization = { path = "../../common/canonical_serialization" }
-crypto = { path = "../../crypto/legacy_crypto" }
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-logger = { path = "../../common/logger" }
-metrics = { path = "../../common/metrics" }
-proto_conv = { path = "../../common/proto_conv" }
-schemadb = { path = "../schemadb" }
-sparse_merkle = { path = "../sparse_merkle" }
-storage_proto = { path = "../storage_proto" }
-types = { path = "../../types" }
+accumulator = { path = "../accumulator", package = "solana_libra_accumulator" }
+canonical_serialization = { path = "../../common/canonical_serialization", package = "solana_libra_canonical_serialization" }
+crypto = { path = "../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+logger = { path = "../../common/logger", package = "solana_libra_logger" }
+metrics = { path = "../../common/metrics", package = "solana_libra_metrics" }
+proto_conv = { path = "../../common/proto_conv", package = "solana_libra_proto_conv" }
+schemadb = { path = "../schemadb", package = "solana_libra_schemadb" }
+sparse_merkle = { path = "../sparse_merkle", package = "solana_libra_sparse_merkle" }
+storage_proto = { path = "../storage_proto", package = "solana_libra_storage_proto" }
+types = { path = "../../types", package = "solana_libra_types" }
 
 [dev-dependencies]
 rusty-fork = "0.2.1"

--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "schemadb"
+name = "solana_libra_schemadb"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -9,8 +9,8 @@ edition = "2018"
 [dependencies]
 lazy_static = "1.3.0"
 
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-metrics = { path = "../../common/metrics" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+metrics = { path = "../../common/metrics", package = "solana_libra_metrics" }
 
 [dependencies.rocksdb]
 git = "https://github.com/pingcap/rust-rocksdb.git"

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "scratchpad"
+name = "solana_libra_scratchpad"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -9,8 +9,8 @@ edition = "2018"
 [dependencies]
 itertools = "0.8.0"
 
-crypto = { path = "../../crypto/legacy_crypto" }
-types = { path = "../../types" }
+crypto = { path = "../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+types = { path = "../../types", package = "solana_libra_types" }
 
 [dev-dependencies]
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }

--- a/storage/sparse_merkle/Cargo.toml
+++ b/storage/sparse_merkle/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sparse_merkle"
+name = "solana_libra_sparse_merkle"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -13,10 +13,10 @@ num-traits = "0.2"
 proptest = "0.9.2"
 proptest-derive = "0.1.2"
 
-crypto = { path = "../../crypto/legacy_crypto" }
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
+crypto = { path = "../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
 serde = { version = "1.0.96", features = ["derive"] }
-types = { path = "../../types" }
+types = { path = "../../types", package = "solana_libra_types" }
 
 [dev-dependencies]
 proptest = "0.9"

--- a/storage/state_view/Cargo.toml
+++ b/storage/state_view/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "state_view"
+name = "solana_libra_state_view"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -7,5 +7,5 @@ publish = false
 edition = "2018"
 
 [dependencies]
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-types = { path = "../../types" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+types = { path = "../../types", package = "solana_libra_types" }

--- a/storage/storage_client/Cargo.toml
+++ b/storage/storage_client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "storage_client"
+name = "solana_libra_storage_client"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -12,12 +12,12 @@ futures_01 = { version = "0.1.25", package = "futures" }
 grpcio = "0.4.4"
 protobuf = "2.7"
 
-canonical_serialization = { path = "../../common/canonical_serialization" }
-crypto = { path = "../../crypto/legacy_crypto" }
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-metrics = { path = "../../common/metrics" }
-proto_conv = { path = "../../common/proto_conv" }
-scratchpad = { path = "../scratchpad" }
-state_view = { path = "../state_view" }
-storage_proto = { path = "../storage_proto" }
-types = { path = "../../types" }
+canonical_serialization = { path = "../../common/canonical_serialization", package = "solana_libra_canonical_serialization" }
+crypto = { path = "../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+metrics = { path = "../../common/metrics", package = "solana_libra_metrics" }
+proto_conv = { path = "../../common/proto_conv", package = "solana_libra_proto_conv" }
+scratchpad = { path = "../scratchpad", package = "solana_libra_scratchpad" }
+state_view = { path = "../state_view", package = "solana_libra_state_view" }
+storage_proto = { path = "../storage_proto", package = "solana_libra_storage_proto" }
+types = { path = "../../types", package = "solana_libra_types" }

--- a/storage/storage_client/Cargo.toml
+++ b/storage/storage_client/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 futures = { version = "0.3.0-alpha.13", package = "futures-preview", features = ["compat"] }
 futures_01 = { version = "0.1.25", package = "futures" }
-grpcio = "0.4.4"
+grpcio = { version = "0.4.4", default-features = false, features = ["protobuf-codec"] }
 protobuf = "2.7"
 
 canonical_serialization = { path = "../../common/canonical_serialization", package = "solana_libra_canonical_serialization" }

--- a/storage/storage_proto/Cargo.toml
+++ b/storage/storage_proto/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.1.28"
-grpcio = "0.4.4"
+grpcio = { version = "0.4.4", default-features = false, features = ["protobuf-codec"] }
 proptest = "0.9.2"
 proptest-derive = "0.1.0"
 protobuf = "2.7"

--- a/storage/storage_proto/Cargo.toml
+++ b/storage/storage_proto/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "storage_proto"
+name = "solana_libra_storage_proto"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -13,10 +13,10 @@ proptest = "0.9.2"
 proptest-derive = "0.1.0"
 protobuf = "2.7"
 
-crypto = { path = "../../crypto/legacy_crypto" }
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-proto_conv = { path = "../../common/proto_conv", features = ["derive"] }
-types = { path = "../../types" }
+crypto = { path = "../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+proto_conv = { path = "../../common/proto_conv", features = ["derive"], package = "solana_libra_proto_conv" }
+types = { path = "../../types", package = "solana_libra_types" }
 
 [build-dependencies]
-build_helpers = { path = "../../common/build_helpers" }
+build_helpers = { path = "../../common/build_helpers", package = "solana_libra_build_helpers" }

--- a/storage/storage_service/Cargo.toml
+++ b/storage/storage_service/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "storage_service"
+name = "solana_libra_storage_service"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -11,20 +11,20 @@ futures = { version = "0.3.0-alpha.13", package = "futures-preview", features = 
 grpcio = "0.4.4"
 protobuf = "2.7"
 
-canonical_serialization = { path = "../../common/canonical_serialization" }
-config = { path = "../../config" }
-crypto = { path = "../../crypto/legacy_crypto" }
-debug_interface = { path = "../../common/debug_interface" }
-executable_helpers = { path = "../../common/executable_helpers" }
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
-grpc_helpers = { path = "../../common/grpc_helpers" }
-libradb = { path = "../libradb" }
-logger = { path = "../../common/logger" }
-metrics = { path = "../../common/metrics" }
-proto_conv = { path = "../../common/proto_conv", features = ["derive"] }
-storage_client = { path = "../storage_client" }
-storage_proto = { path = "../storage_proto" }
-types = { path = "../../types" }
+canonical_serialization = { path = "../../common/canonical_serialization", package = "solana_libra_canonical_serialization" }
+config = { path = "../../config", package = "solana_libra_config" }
+crypto = { path = "../../crypto/legacy_crypto", package = "solana_libra_crypto" }
+debug_interface = { path = "../../common/debug_interface", package = "solana_libra_debug_interface" }
+executable_helpers = { path = "../../common/executable_helpers", package = "solana_libra_executable_helpers" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
+grpc_helpers = { path = "../../common/grpc_helpers", package = "solana_libra_grpc_helpers" }
+libradb = { path = "../libradb", package = "solana_libradb" }
+logger = { path = "../../common/logger", package = "solana_libra_logger" }
+metrics = { path = "../../common/metrics", package = "solana_libra_metrics" }
+proto_conv = { path = "../../common/proto_conv", features = ["derive"], package = "solana_libra_proto_conv" }
+storage_client = { path = "../storage_client", package = "solana_libra_storage_client" }
+storage_proto = { path = "../storage_proto", package = "solana_libra_storage_proto" }
+types = { path = "../../types", package = "solana_libra_types" }
 
 [dev-dependencies]
 itertools = "0.8.0"

--- a/storage/storage_service/Cargo.toml
+++ b/storage/storage_service/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 futures = { version = "0.3.0-alpha.13", package = "futures-preview", features = ["compat"] }
-grpcio = "0.4.4"
+grpcio = { version = "0.4.4", default-features = false, features = ["protobuf-codec"] }
 protobuf = "2.7"
 
 canonical_serialization = { path = "../../common/canonical_serialization", package = "solana_libra_canonical_serialization" }

--- a/storage/storage_service/src/main.rs
+++ b/storage/storage_service/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use solana_libra_storage_service as storage_service;
+
 use executable_helpers::helpers::{
     setup_executable, ARG_CONFIG_PATH, ARG_DISABLE_LOGGING, ARG_PEER_ID,
 };

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "testsuite"
+name = "solana_libra_testsuite"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -14,8 +14,8 @@ rust_decimal = "1.0.1"
 # In order to limit the potential waiting time for binaries to be built while
 # running tests all binaries which are being tested under this testsuite
 # should have their crates listed as dev-dependencies.
-cli = { path = "../client", package="client"}
-generate_keypair = { path = "../config/generate_keypair" }
-libra_swarm = { path = "../libra_swarm" }
-logger = { path = "../common/logger" }
+cli = { path = "../client", package = "solana_libra_client" }
+generate_keypair = { path = "../config/generate_keypair", package = "solana_libra_generate_keypair" }
+libra_swarm = { path = "../libra_swarm", package = "solana_libra_swarm" }
+logger = { path = "../common/logger", package = "solana_libra_logger" }
 tempfile = "3.1.0"

--- a/testsuite/cluster_test/Cargo.toml
+++ b/testsuite/cluster_test/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cluster_test"
+name = "solana_libra_cluster_test"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -7,7 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
 rand = "0.6.5"
 rusoto_core = "0.40.0"
 rusoto_kinesis = "0.40.0"

--- a/testsuite/cluster_test/src/main.rs
+++ b/testsuite/cluster_test/src/main.rs
@@ -1,3 +1,5 @@
+use solana_libra_cluster_test as cluster_test;
+
 use clap::{App, Arg, ArgGroup, ArgMatches};
 use cluster_test::{
     aws::Aws,

--- a/testsuite/libra_fuzzer/Cargo.toml
+++ b/testsuite/libra_fuzzer/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
-name = "libra_fuzzer"
+name = "solana_libra_fuzzer"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
+failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }
 byteorder = "1.3.2"
 hex = "0.3.2"
 lazy_static = "1.3"
 proptest = "0.9.3"
 sha-1 = "0.8"
 structopt = "0.2.15"
-proto_conv = { path = "../../common/proto_conv" }
-canonical_serialization = { path = "../../common/canonical_serialization" }
+proto_conv = { path = "../../common/proto_conv", package = "solana_libra_proto_conv" }
+canonical_serialization = { path = "../../common/canonical_serialization", package = "solana_libra_canonical_serialization" }
 
 # List out modules with data structures being fuzzed here.
-types = { path = "../../types" }
-vm = { path = "../../language/vm" }
-vm_runtime = { path = "../../language/vm/vm_runtime" }
+types = { path = "../../types", package = "solana_libra_types" }
+vm = { path = "../../language/vm", package = "solana_libra_vm" }
+vm_runtime = { path = "../../language/vm/vm_runtime", package = "solana_libra_vm_runtime" }
 
 [dev-dependencies]
 datatest = "0.3.5"

--- a/testsuite/libra_fuzzer/fuzz/Cargo.toml
+++ b/testsuite/libra_fuzzer/fuzz/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "libra_fuzzer_fuzz"
+name = "solana_libra_fuzzer_fuzz"
 version = "0.1.0"
 edition = "2018"
 authors = ["Automatically generated"]
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
-libra_fuzzer = { path = ".." }
+libra_fuzzer = { path = "..", package = "solana_libra_fuzzer" }
 lazy_static = "1.3.0"
 
 # futures-preview is pinned to 0.3.0-alpha.14 by some other packages. The latest version
@@ -23,5 +23,5 @@ futures-preview = "=0.3.0-alpha.14"
 members = ["."]
 
 [[bin]]
-name = "fuzz_runner"
+name = "solana_libra_fuzz_runner"
 path = "fuzz_targets/fuzz_runner.rs"

--- a/testsuite/libra_fuzzer/src/main.rs
+++ b/testsuite/libra_fuzzer/src/main.rs
@@ -3,6 +3,8 @@
 
 //! Helpers for fuzz testing.
 
+use solana_libra_fuzzer as libra_fuzzer;
+
 use lazy_static::lazy_static;
 use libra_fuzzer::{commands, FuzzTarget};
 use std::{env, ffi::OsString, fs, path::PathBuf};

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "types"
+name = "solana_libra_types"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ chrono = "0.4.7"
 hex = "0.3.2"
 itertools = "0.8.0"
 lazy_static = "1.3.0"
-logger = { path = "../common/logger" }
+logger = { path = "../common/logger", package = "solana_libra_logger" }
 proptest = "0.9"
 proptest-derive = "0.1.0"
 protobuf = "2.7"
@@ -24,19 +24,20 @@ serde = { version = "1.0.96", features = ["derive"] }
 serde_json = "1.0.40"
 tiny-keccak = "1.5.0"
 
-canonical_serialization = { path = "../common/canonical_serialization"}
-crypto = { path = "../crypto/legacy_crypto" }
-nextgen_crypto = { path = "../crypto/nextgen_crypto" }
-failure = { path = "../common/failure_ext", package = "failure_ext" }
-proptest_helpers = { path = "../common/proptest_helpers" }
-proto_conv = { path = "../common/proto_conv", features = ["derive"] }
+canonical_serialization = { path = "../common/canonical_serialization", package = "solana_libra_canonical_serialization" }
+crypto = { path = "../crypto/legacy_crypto", package = "solana_libra_crypto" }
+nextgen_crypto = { path = "../crypto/nextgen_crypto", package = "solana_libra_nextgen_crypto" }
+failure = { path = "../common/failure_ext", package = "solana_libra_failure_ext" }
+proptest_helpers = { path = "../common/proptest_helpers", package = "solana_libra_proptest_helpers" }
+proto_conv = { path = "../common/proto_conv", features = ["derive"], package = "solana_libra_proto_conv" }
 
 [build-dependencies]
-build_helpers = { path = "../common/build_helpers" }
+build_helpers = { path = "../common/build_helpers", package = "solana_libra_build_helpers" }
 
 [dev-dependencies.nextgen_crypto]
 features = ["testing"]
 path = "../crypto/nextgen_crypto"
+package = "solana_libra_nextgen_crypto"
 
 [features]
 default = []

--- a/vm_validator/Cargo.toml
+++ b/vm_validator/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "vm_validator"
+name = "solana_libra_vm_validator"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -9,23 +9,23 @@ edition = "2018"
 [dependencies]
 futures = "0.1.28"
 
-config = { path = "../config" }
-crypto = { path = "../crypto/legacy_crypto" }
-failure = { path = "../common/failure_ext", package = "failure_ext" }
-proto_conv = { path = "../common/proto_conv" }
-scratchpad = { path = "../storage/scratchpad" }
-state_view = { path = "../storage/state_view" }
-storage_client = { path = "../storage/storage_client" }
-types = { path = "../types" }
-vm_runtime = { path = "../language/vm/vm_runtime" }
+config = { path = "../config", package = "solana_libra_config" }
+crypto = { path = "../crypto/legacy_crypto", package = "solana_libra_crypto" }
+failure = { path = "../common/failure_ext", package = "solana_libra_failure_ext" }
+proto_conv = { path = "../common/proto_conv", package = "solana_libra_proto_conv" }
+scratchpad = { path = "../storage/scratchpad", package = "solana_libra_scratchpad" }
+state_view = { path = "../storage/state_view", package = "solana_libra_state_view" }
+storage_client = { path = "../storage/storage_client", package = "solana_libra_storage_client" }
+types = { path = "../types", package = "solana_libra_types" }
+vm_runtime = { path = "../language/vm/vm_runtime", package = "solana_libra_vm_runtime" }
 
 [dev-dependencies]
 grpcio = "0.4.4"
 assert_matches = "1.3.0"
 
-execution_proto = { path = "../execution/execution_proto" }
-execution_service = { path = "../execution/execution_service" }
-grpc_helpers = { path = "../common/grpc_helpers" }
-storage_service = { path = "../storage/storage_service" }
-vm_genesis = { path = "../language/vm/vm_genesis" }
-config_builder = { path = "../config/config_builder" }
+execution_proto = { path = "../execution/execution_proto", package = "solana_libra_execution_proto" }
+execution_service = { path = "../execution/execution_service", package = "solana_libra_execution_service" }
+grpc_helpers = { path = "../common/grpc_helpers", package = "solana_libra_grpc_helpers" }
+storage_service = { path = "../storage/storage_service", package = "solana_libra_storage_service" }
+vm_genesis = { path = "../language/vm/vm_genesis", package = "solana_libra_vm_genesis" }
+config_builder = { path = "../config/config_builder", package = "solana_libra_config_builder" }

--- a/vm_validator/Cargo.toml
+++ b/vm_validator/Cargo.toml
@@ -20,7 +20,7 @@ types = { path = "../types", package = "solana_libra_types" }
 vm_runtime = { path = "../language/vm/vm_runtime", package = "solana_libra_vm_runtime" }
 
 [dev-dependencies]
-grpcio = "0.4.4"
+grpcio = { version = "0.4.4", default-features = false, features = ["protobuf-codec"] }
 assert_matches = "1.3.0"
 
 execution_proto = { path = "../execution/execution_proto", package = "solana_libra_execution_proto" }


### PR DESCRIPTION
#### Problem

We don't want to ask Solana developers or any downstream dependencies to install the Go compiler.

#### Proposed Changes

Remove default feature "secure" from `grpcio`, which provides from TLS functionality via boringssl that doesn't appear to be used at all.