### PR TITLE
Drop the dependency on the Go compiler

### DIFF
--- a/admission_control/admission_control_proto/Cargo.toml
+++ b/admission_control/admission_control_proto/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 futures = "0.1.28"
 futures03 = { version = "=0.3.0-alpha.17", package = "futures-preview" }
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 protobuf = "2.7"
 
 failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }

--- a/admission_control/admission_control_service/Cargo.toml
+++ b/admission_control/admission_control_service/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 futures = "0.1.28"
 futures03 = { version = "=0.3.0-alpha.17", package = "futures-preview" }
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 lazy_static = "1.3.0"
 protobuf = "2.7"
 

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 bincode = "1.1.4"
 clap = "2.33.0"
 futures = "0.1.28"
-grpcio = "0.4"
+grpcio = { version = "0.4", default-features = false, features = ["protobuf-codec"] }
 itertools = "0.8.0"
 lazy_static = "1.2.0"
 protobuf = "2.7"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 bincode = "1.1.1"
 futures = "0.1.28"
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 hex = "0.3.2"
 hyper = "0.12.33"
 itertools = "0.8.0"

--- a/common/debug_interface/Cargo.toml
+++ b/common/debug_interface/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 futures = "0.1.28"
 protobuf = "2.7"
 

--- a/common/grpc_helpers/Cargo.toml
+++ b/common/grpc_helpers/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 futures = { version = "0.3.0-alpha.13", package = "futures-preview", features = ["compat"] }
 futures_01 = { version = "0.1.25", package = "futures" }
 

--- a/common/grpcio-extras/Cargo.toml
+++ b/common/grpcio-extras/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 
 [dependencies]
 futures = "0.1.25"
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }

--- a/common/metrics/Cargo.toml
+++ b/common/metrics/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.1.28"
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 hyper = "0.12.33"
 lazy_static = "1.3.0"
 protobuf = "2.7"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 byteorder = "1.3.2"
 bytes = "0.4.12"
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 futures = { version = "=0.3.0-alpha.17", package = "futures-preview", features = ["io-compat", "compat"] }
 futures_locks = { version = "=0.3.0", package = "futures-locks", features=["tokio"]}
 mirai-annotations = "^1.2.2"

--- a/crypto/secret_service/Cargo.toml
+++ b/crypto/secret_service/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.1.28"
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 protobuf = "2.7"
 
 config = { path = "../../config", package = "solana_libra_config" }

--- a/execution/execution_client/Cargo.toml
+++ b/execution/execution_client/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-grpcio = "0.4.4"
+grpcio = { version = "0.4.4", default-features = false, features = ["protobuf-codec"] }
 
 execution_proto = { path = "../execution_proto", package = "solana_libra_execution_proto" }
 failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext" }

--- a/execution/execution_proto/Cargo.toml
+++ b/execution/execution_proto/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.1.28"
-grpcio = "0.4.4"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 proptest = "0.9.2"
 proptest-derive = "0.1.0"
 protobuf = "2.7"

--- a/execution/execution_service/Cargo.toml
+++ b/execution/execution_service/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 futures01 = { package = "futures", version = "0.1.26" }
 futures03 = { package = "futures-preview", version = "=0.3.0-alpha.17", features = ["compat"] }
-grpcio = "0.4.4"
+grpcio = { version = "0.4.4", default-features = false, features = ["protobuf-codec"] }
 
 config = { path = "../../config", package = "solana_libra_config" }
 execution_proto = { path = "../execution_proto", package = "solana_libra_execution_proto" }

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -27,7 +27,7 @@ vm_runtime = { path = "../../language/vm/vm_runtime", package = "solana_libra_vm
 vm_genesis = { path = "../../language/vm/vm_genesis", package = "solana_libra_vm_genesis" }
 
 [dev-dependencies]
-grpcio = "0.4.4"
+grpcio = { version = "0.4.4", default-features = false, features = ["protobuf-codec"] }
 proptest = "0.9.2"
 rusty-fork = "0.2.1"
 

--- a/libra_node/Cargo.toml
+++ b/libra_node/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 grpcio-sys = "0.4.4"
 signal-hook = "0.1.10"
 tokio = "0.1.22"

--- a/libra_swarm/Cargo.toml
+++ b/libra_swarm/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 bincode = "1.1.1"
 ctrlc = "3.1.3"
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 lazy_static = "1.2.0"
 structopt = "0.2.15"
 tempfile = "3.1.0"

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 chrono = "0.4.7"
 futures = "0.1.28"
 futures-preview = { version = "=0.3.0-alpha.17", package = "futures-preview", features = ["compat"] }
-grpcio = "0.4.3"
+grpcio = { version = "0.4.3", default-features = false, features = ["protobuf-codec"] }
 grpcio-sys = "0.4.4"
 lazy_static = "1.3.0"
 lru-cache = "0.1.1"

--- a/storage/storage_client/Cargo.toml
+++ b/storage/storage_client/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 futures = { version = "0.3.0-alpha.13", package = "futures-preview", features = ["compat"] }
 futures_01 = { version = "0.1.25", package = "futures" }
-grpcio = "0.4.4"
+grpcio = { version = "0.4.4", default-features = false, features = ["protobuf-codec"] }
 protobuf = "2.7"
 
 canonical_serialization = { path = "../../common/canonical_serialization", package = "solana_libra_canonical_serialization" }

--- a/storage/storage_proto/Cargo.toml
+++ b/storage/storage_proto/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.1.28"
-grpcio = "0.4.4"
+grpcio = { version = "0.4.4", default-features = false, features = ["protobuf-codec"] }
 proptest = "0.9.2"
 proptest-derive = "0.1.0"
 protobuf = "2.7"

--- a/storage/storage_service/Cargo.toml
+++ b/storage/storage_service/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 futures = { version = "0.3.0-alpha.13", package = "futures-preview", features = ["compat"] }
-grpcio = "0.4.4"
+grpcio = { version = "0.4.4", default-features = false, features = ["protobuf-codec"] }
 protobuf = "2.7"
 
 canonical_serialization = { path = "../../common/canonical_serialization", package = "solana_libra_canonical_serialization" }

--- a/vm_validator/Cargo.toml
+++ b/vm_validator/Cargo.toml
@@ -20,7 +20,7 @@ types = { path = "../types", package = "solana_libra_types" }
 vm_runtime = { path = "../language/vm/vm_runtime", package = "solana_libra_vm_runtime" }
 
 [dev-dependencies]
-grpcio = "0.4.4"
+grpcio = { version = "0.4.4", default-features = false, features = ["protobuf-codec"] }
 assert_matches = "1.3.0"
 
 execution_proto = { path = "../execution/execution_proto", package = "solana_libra_execution_proto" }


### PR DESCRIPTION
#### Problem

We don't want to ask Solana developers or any downstream dependencies to install the Go compiler.

#### Proposed Changes

Remove default feature "secure" from `grpcio`, which provides from TLS functionality via boringssl that doesn't appear to be used at all.