### PR TITLE
Small fixes for publishing crates

### DIFF
--- a/language/compiler/ir_to_bytecode/syntax/src/lib.rs
+++ b/language/compiler/ir_to_bytecode/syntax/src/lib.rs
@@ -208,5 +208,4 @@ pub mod ast;
 #[rustfmt::skip]
 #[allow(clippy::all)]
 #[allow(deprecated)]
-#[path = concat!(env!("OUT_DIR"), "/syntax.rs")]
 pub mod syntax;

--- a/language/e2e_tests/Cargo.toml
+++ b/language/e2e_tests/Cargo.toml
@@ -28,6 +28,6 @@ protobuf = "=2.8.0"
 proto_conv = { path = "../../common/proto_conv", features = ["derive"], package = "solana_libra_proto_conv", version = "0.0.0" }
 tiny-keccak = "1.5.0"
 vm_genesis = { path = "../vm/vm_genesis", package = "solana_libra_vm_genesis", version = "0.0.0" }
-config =  { path = "../../config", package = "solana_libra_config" }
+config =  { path = "../../config", package = "solana_libra_config", version = "0.0.0" }
 logger = { path = "../../common/logger", package = "solana_libra_logger", version = "0.0.0" }
 stdlib = { path = "../stdlib", package = "solana_libra_stdlib", version = "0.0.0" }

--- a/language/functional_tests/Cargo.toml
+++ b/language/functional_tests/Cargo.toml
@@ -7,6 +7,7 @@ homepage = "https://solana.com/"
 description = "Solana Libra functional_tests"
 license = "Apache-2.0"
 edition = "2018"
+publish = false
 
 [dependencies]
 failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext", version = "0.0.0" }


### PR DESCRIPTION
- fix `ir_to_bytecode_syntax` library
- Add missing version specification to `e2e_tests`'s `Cargo.toml`
- Diable publish of functional_tests 