### PR TITLE
Bump crossbeam version to 0.6.0

### DIFF
--- a/ci/checks.sh
+++ b/ci/checks.sh
@@ -11,6 +11,6 @@ cargo fmt --all -- --check
 #cargo clippy --all -- --deny=warnings
 cargo update
 cargo audit --version
-cargo audit --ignore RUSTSEC-2019-0011 # https://github.com/solana-labs/solana/issues/5207
+cargo audit
 #ci/nits.sh
 ci/order-crates-for-publishing.py

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 backtrace = { version = "0.3.33", features = ["serialize-serde"] }
 chrono = "0.4.7"
-crossbeam = "^0.4.1"
+crossbeam = "0.6.0"
 futures = "0.1.28"
 hyper = "0.12.33"
 itertools = "0.8.0"


### PR DESCRIPTION
Bump crossbeam version to avoid `cargo audit` error [https://github.com/RustSec/advisory-db/blob/master/crates/memoffset/RUSTSEC-2019-0011.toml](url)