### PR TITLE
Remove circular dependency in crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4005,7 +4005,6 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-libra-crypto 0.1.0",
  "solana_libra_failure_ext 0.1.0",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/crypto/crypto_derive/Cargo.toml
+++ b/crypto/crypto_derive/Cargo.toml
@@ -13,5 +13,4 @@ quote = "1.0.0"
 proc-macro2 = "1.0.1"
 
 [dev-dependencies]
-solana-libra-crypto = { path = "../crypto"}
 failure = { path = "../../common/failure_ext", package = "solana_libra_failure_ext"}

--- a/crypto/crypto_derive/src/lib.rs
+++ b/crypto/crypto_derive/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! ## Example
 //!
-//! ```
+//! ```ignore
 //! # #[macro_use] extern crate solana_libra_crypto_derive;
 //! use solana_libra_crypto::{
 //!     hash::HashValue,


### PR DESCRIPTION
Disables a doc-test to remove the circular dependency. This test appears redundant, as it only checks that the procedural macros successfully build, which also occurs in any build of the `crypto` crate.

Fixes #36 