### PR TITLE
Featurize service metrics

### DIFF
--- a/common/metrics/Cargo.toml
+++ b/common/metrics/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.1.28"
-grpcio = { version = "=0.5.0-alpha.4", default-features = false }
+grpcio = { version = "=0.5.0-alpha.4", default-features = false, optional = true }
 hyper = "0.12.34"
 lazy_static = "1.3.0"
 serde_json = "1.0.40"
@@ -23,3 +23,7 @@ solana-libra-logger = { path = "../logger", version = "0.1.0" }
 [dev-dependencies]
 rusty-fork = "0.2.1"
 assert_approx_eq = "1.1.0"
+
+[features]
+service-metrics = ["grpcio"]
+default = ["service-metrics"]

--- a/common/metrics/src/counters.rs
+++ b/common/metrics/src/counters.rs
@@ -1,10 +1,12 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "service-metrics")]
 use crate::ServiceMetrics;
 use lazy_static::lazy_static;
 use prometheus::IntCounter;
 
+#[cfg(feature = "service-metrics")]
 lazy_static! {
     pub static ref SVC_COUNTERS: ServiceMetrics = ServiceMetrics::new_and_registered();
 }

--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -10,7 +10,9 @@ pub mod counters;
 mod json_encoder;
 pub mod metric_server;
 
+#[cfg(feature = "service-metrics")]
 mod service_metrics;
+#[cfg(feature = "service-metrics")]
 pub use service_metrics::ServiceMetrics;
 
 mod op_counters;

--- a/common/metrics/src/service_metrics.rs
+++ b/common/metrics/src/service_metrics.rs
@@ -1,5 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
+#![cfg(feature = "service-metrics")]
 
 /*!
 `ServiceMetrics` is a metric [`Collector`](prometheus::core::Collector) to capture key

--- a/language/vm/vm_runtime/Cargo.toml
+++ b/language/vm/vm_runtime/Cargo.toml
@@ -23,7 +23,7 @@ solana_libra_canonical_serialization = { path = "../../../common/canonical_seria
 solana-libra-config = { path = "../../../config", version = "0.1.0" }
 solana-libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
 solana-libra-logger = { path = "../../../common/logger", version = "0.1.0" }
-solana-libra-metrics = { path = "../../../common/metrics", version = "0.1.0" }
+solana-libra-metrics = { path = "../../../common/metrics", version = "0.1.0", default-features = false }
 solana_libra_state_view = { path = "../../../storage/state_view", version = "0.1.0" }
 solana-libra-types = { path = "../../../types", version = "0.1.0" }
 solana-libra-vm = { path = "../", version = "0.1.0" }


### PR DESCRIPTION
Featurize the `service_metrics` module so that solana can stop depending on `grpcio`. This prevents conflicting versions of `clang-sys` in the solana dependency tree.